### PR TITLE
Add multi-arch Docker image build to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,3 +28,36 @@ jobs:
 
       - name: Pytest
         run: cd tests && uv run pytest -v
+
+  build-and-push:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: lint-and-test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Adds a `build-and-push` job to CI that builds `linux/amd64` + `linux/arm64` Docker images on push to main
- Runs after `lint-and-test` passes, pushes to GHCR with `:latest` and `:sha` tags
- Uses GHA layer caching (`type=gha`) for fast rebuilds
- Fixes `ImagePullBackOff` on arm64 K3s nodes (Rancher Desktop / Apple Silicon)

## Test plan
- [x] Manually built and pushed multi-arch image — verified arm64 pod pulls and runs on Rancher Desktop K3s
- [ ] Merge to main and confirm `build-and-push` job runs in CI
- [ ] Verify GHCR manifest includes both `amd64` and `arm64` platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)