### PR TITLE
Serialize scrape_matches to prevent navigation timeouts

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -50,6 +50,10 @@ immediately. Do NOT scrape week-by-week — cast a wide net.
 
 ## Scraping Strategy
 
+**Important:** Scrape one target at a time. Call scrape_matches, then
+submit_matches, then move to the next target. Do NOT call multiple
+scrape_matches in parallel.
+
 1. Call get_today_info to learn the date and day of week.
 2. Choose your date range:
    - **Primary range**: today through **2026-06-30** (end of season) to

--- a/src/agent/core.py
+++ b/src/agent/core.py
@@ -52,4 +52,5 @@ def create_agent(settings: AgentSettings) -> Agent[AgentDeps, AgentResult]:
         system_prompt=_load_system_prompt(),
         tools=[get_today_info, scrape_matches, submit_matches],
         retries=1,
+        max_concurrency=1,  # One Chromium at a time — fits pod resources, polite to MLS
     )


### PR DESCRIPTION
## Summary
- Set `max_concurrency=1` on the PydanticAI Agent so tool calls execute one at a time instead of in parallel
- Reinforce sequential scraping in `agent.md` system prompt (scrape → submit → next target)
- Prevents 3 concurrent headless Chromium instances from exceeding pod resources (1 CPU / 2Gi) and timing out

## Test plan
- [x] `cd tests && uv run pytest` — all 16 tests pass
- [ ] Merge, wait for CI to build image
- [ ] `./scripts/trigger.sh prod --follow` — confirm scrapes run sequentially (timestamps spaced apart) and navigation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)