### PR TITLE
Fix DeadlineExceeded failures + stale schedule docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **LLM routing:** All calls go through iron-claw proxy (`ANTHROPIC_BASE_URL`)
 - **Scraping:** `mls-match-scraper` library (Playwright + CSS selectors, zero LLM tokens)
 - **Match submission:** `mls-match-scraper` MatchQueueClient → RabbitMQ → Celery workers
-- **Deployment:** K3s CronJob (daily at 14:00 UTC)
+- **Deployment:** K3s CronJob (4x/day at 02:00, 08:00, 14:00, 20:00 UTC)
 - **Default model:** `claude-haiku-4-5-20251001` (cheap, fast — fits small token budgets)
 
 ## Key Technology Choices

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Agentic match data manager for youth soccer. Uses PydanticAI to reason about wha
 ## Architecture
 
 ```
-K3s CronJob (daily 14:00 UTC)
+K3s CronJob (4x/day: 02:00, 08:00, 14:00, 20:00 UTC)
   → match-scraper-agent run --json-logs
     → PydanticAI Agent (claude-haiku-4-5)
       → LLM reasoning via iron-claw proxy :8100 (RADIUS metering)
@@ -161,4 +161,4 @@ kubectl apply -f k3s/match-scraper-agent/secret.yaml
 kubectl apply -f k3s/match-scraper-agent/cronjob.yaml
 ```
 
-The CronJob runs daily at 14:00 UTC with `concurrencyPolicy: Forbid`.
+The CronJob runs 4x/day at 02:00, 08:00, 14:00, 20:00 UTC with `concurrencyPolicy: Forbid`.

--- a/docs/infrastructure-topology.md
+++ b/docs/infrastructure-topology.md
@@ -17,7 +17,7 @@ All scraper components run here. This IS production for match data — it writes
 
 | Namespace | Component | Type |
 |-----------|-----------|------|
-| `match-scraper` | match-scraper-agent | CronJob (daily 14:00 UTC) |
+| `match-scraper` | match-scraper-agent | CronJob (4x/day) |
 | `match-scraper` | RabbitMQ | StatefulSet |
 | `match-scraper` | Celery worker | Deployment |
 | `iron-claw` | iron-claw-proxy | Deployment |

--- a/k3s/match-scraper-agent/cronjob.yaml
+++ b/k3s/match-scraper-agent/cronjob.yaml
@@ -11,7 +11,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 1
-      activeDeadlineSeconds: 600
+      activeDeadlineSeconds: 1800
       template:
         spec:
           restartPolicy: Never


### PR DESCRIPTION
## Summary
- Increase `activeDeadlineSeconds` from 600 → 1800 (10 min → 30 min) to fix DeadlineExceeded failures — the agent + Playwright flow takes ~9 minutes
- Fix stale "daily 14:00 UTC" schedule references in README, CLAUDE.md, and docs (actual schedule is 4x/day)

## Verification
- CronJob redeployed: `kubectl apply` confirmed `activeDeadlineSeconds: 1800`
- Manual trigger (`trigger.sh prod --follow`) completed successfully in ~9 min — no DeadlineExceeded
- Job status: `SuccessCriteriaMet`
- 550 matches scraped across 3 targets (U14 HG, U13 HG, U14 Academy)

## Test plan
- [x] `kubectl get cronjob` confirms schedule `0 2,8,14,20 * * *` and deadline 1800
- [x] Manual job completes within deadline (verified: ~9 min)
- [x] Next scheduled run should succeed (monitor at 02:00 UTC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)