### PR TITLE
Fix RabbitMQ ACCESS_REFUSED: use correct credentials

### DIFF
--- a/k3s/match-scraper-agent/configmap.yaml
+++ b/k3s/match-scraper-agent/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   AGENT_PROXY_BASE_URL: "http://iron-claw-proxy.iron-claw.svc.cluster.local:8100"
   AGENT_MODEL_NAME: "claude-haiku-4-5-20251001"
-  AGENT_RABBITMQ_URL: "amqp://guest:guest@messaging-rabbitmq.match-scraper.svc.cluster.local:5672/"
+  AGENT_RABBITMQ_URL: "amqp://admin:admin123@messaging-rabbitmq.match-scraper.svc.cluster.local:5672//"
   AGENT_QUEUE_NAME: "matches.prod"
   AGENT_LEAGUE: "Homegrown"
   AGENT_AGE_GROUP: "U14"


### PR DESCRIPTION
## Summary
- Fix `AGENT_RABBITMQ_URL` in configmap: `guest:guest` → `admin:admin123` (the only user on the RabbitMQ instance)
- Add missing trailing slash in vhost path to match the working Celery worker config

## Root cause
RabbitMQ has no `guest` user — only `admin`. The agent configmap was set up with default Celery credentials that don't exist on the broker.

## Verification
- ConfigMap redeployed to K3s
- Manual trigger completed successfully: **1,100 matches scraped, 3,925 submitted, 0 errors**
- Previous run (with `guest:guest`): 550 matches scraped, 0 submitted, 550 ACCESS_REFUSED errors

Closes #19

## Test plan
- [x] `kubectl apply` configmap — confirmed
- [x] Manual trigger (`trigger.sh prod --follow`) — all submissions succeeded
- [x] No ACCESS_REFUSED errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)