### PR TITLE
feat: Add Florida HG scrape targets (U14, U13)

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -13,11 +13,13 @@ app plays for the U14 HG IFA team. "IFA" is the club name in the MT system.
 
 ## What to Scrape
 
-You MUST scrape all three of these targets, in priority order:
+You MUST scrape all five of these targets, in priority order:
 
 1. **U14 HG Northeast** (top priority — this is our team)
 2. **U13 HG Northeast**
-3. **U14 Academy New England** (conference="New England")
+3. **U14 HG Florida** (division="Florida")
+4. **U13 HG Florida** (division="Florida")
+5. **U14 Academy New England** (conference="New England")
 
 For each target, call scrape_matches with the appropriate league, age_group,
 division, and conference. Do NOT pass a club filter — scrape the full

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -78,6 +78,16 @@ _TARGET_SCRAPER_CONFIG: dict[str, dict[str, str]] = {
         "league": "Academy",
         "conference": "New England",
     },
+    "u14-hg-florida": {
+        "age_group": "U14",
+        "league": "Homegrown",
+        "division": "Florida",
+    },
+    "u13-hg-florida": {
+        "age_group": "U13",
+        "league": "Homegrown",
+        "division": "Florida",
+    },
 }
 
 _TARGET_PROMPTS: dict[str, str] = {
@@ -98,6 +108,14 @@ _TARGET_PROMPTS: dict[str, str] = {
     "u14-academy-ifa": (
         "Only scrape U14 Academy New England (conference='New England') today. "
         "Only IFA Academy matches will be submitted. Do not scrape other targets."
+    ),
+    "u14-hg-florida": (
+        "Only scrape U14 Homegrown Florida (division='Florida') today. "
+        "Do not scrape other targets."
+    ),
+    "u13-hg-florida": (
+        "Only scrape U13 Homegrown Florida (division='Florida') today. "
+        "Do not scrape other targets."
     ),
 }
 


### PR DESCRIPTION
## Summary

- Update `agent.md` system prompt: expand from 3 to 5 scrape targets, adding U14 HG Florida (priority 3) and U13 HG Florida (priority 4)
- Add `u14-hg-florida` and `u13-hg-florida` to `_TARGET_SCRAPER_CONFIG` and `_TARGET_PROMPTS` in CLI for manual targeted runs

Enables: `match-scraper-agent run --target u14-hg-florida --env local`

## Test plan

- [ ] `match-scraper-agent run --target u14-hg-florida --env local` runs successfully
- [ ] `match-scraper-agent run --target u13-hg-florida --env local` runs successfully
- [ ] Full agent run (no --target) scrapes all 5 targets in priority order
- [ ] Verify invalid target still errors: `match-scraper-agent run --target bad-target`

🤖 Generated with [Claude Code](https://claude.com/claude-code)