### PR TITLE
feat: Add --submit flag and Florida backfill tooling

### DIFF
--- a/k3s/backfill/florida-u14-week01.yaml
+++ b/k3s/backfill/florida-u14-week01.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: backfill-florida-u14-week01
+  namespace: match-scraper
+  labels:
+    app: match-scraper-agent
+    task: backfill
+    division: florida
+    age-group: u14
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
+  template:
+    metadata:
+      labels:
+        app: match-scraper-agent
+        task: backfill
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: agent
+          image: ghcr.io/silverbeer/match-scraper-agent:latest
+          args:
+            - scrape
+            - --target
+            - u14-hg-florida
+            - --from
+            - "2025-08-28"
+            - --to
+            - "2025-09-04"
+            - --submit
+            - --env
+            - prod
+          envFrom:
+            - configMapRef:
+                name: match-scraper-agent-config
+            - secretRef:
+                name: match-scraper-agent-secret
+          resources:
+            requests:
+              cpu: 200m
+              memory: 1Gi
+            limits:
+              cpu: "1"
+              memory: 2Gi

--- a/scripts/backfill-florida.sh
+++ b/scripts/backfill-florida.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+#
+# Backfill Florida HG matches from fall 2025 into Missing Table.
+#
+# Usage:
+#   ./scripts/backfill-florida.sh                    # Show plan (dry run)
+#   ./scripts/backfill-florida.sh --run              # Run week 1 (U14)
+#   ./scripts/backfill-florida.sh --run --week 3     # Run specific week
+#   ./scripts/backfill-florida.sh --run --age u13    # Run U13 instead of U14
+#   ./scripts/backfill-florida.sh --status           # Check job status
+#   ./scripts/backfill-florida.sh --cleanup          # Delete completed backfill jobs
+#
+
+set -e
+
+NAMESPACE="match-scraper"
+IMAGE="ghcr.io/silverbeer/match-scraper-agent:latest"
+
+# Weekly date ranges (2025-08-28 to 2025-12-01)
+WEEKS=(
+  "2025-08-28 2025-09-04"
+  "2025-09-04 2025-09-11"
+  "2025-09-11 2025-09-18"
+  "2025-09-18 2025-09-25"
+  "2025-09-25 2025-10-02"
+  "2025-10-02 2025-10-09"
+  "2025-10-09 2025-10-16"
+  "2025-10-16 2025-10-23"
+  "2025-10-23 2025-10-30"
+  "2025-10-30 2025-11-06"
+  "2025-11-06 2025-11-13"
+  "2025-11-13 2025-11-20"
+  "2025-11-20 2025-11-27"
+  "2025-11-27 2025-12-01"
+)
+
+# Parse arguments
+ACTION="plan"
+WEEK_NUM=""
+AGE_GROUP="u14"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --run) ACTION="run"; shift ;;
+    --status) ACTION="status"; shift ;;
+    --cleanup) ACTION="cleanup"; shift ;;
+    --week) WEEK_NUM="$2"; shift 2 ;;
+    --age) AGE_GROUP="$2"; shift 2 ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+TARGET="${AGE_GROUP}-hg-florida"
+
+if [[ "$ACTION" == "status" ]]; then
+  echo "Backfill job status:"
+  kubectl get jobs -n "$NAMESPACE" -l task=backfill --sort-by=.metadata.creationTimestamp
+  exit 0
+fi
+
+if [[ "$ACTION" == "cleanup" ]]; then
+  echo "Deleting completed backfill jobs..."
+  kubectl delete jobs -n "$NAMESPACE" -l task=backfill --field-selector status.successful=1
+  exit 0
+fi
+
+if [[ "$ACTION" == "plan" ]]; then
+  echo "Florida HG Backfill Plan (${AGE_GROUP^^})"
+  echo "========================================="
+  echo ""
+  for i in "${!WEEKS[@]}"; do
+    read -r from_date to_date <<< "${WEEKS[$i]}"
+    week=$((i + 1))
+    printf "  Week %2d: %s to %s\n" "$week" "$from_date" "$to_date"
+  done
+  echo ""
+  echo "To run week 1:  $0 --run --week 1 --age $AGE_GROUP"
+  echo "To run all:     $0 --run --age $AGE_GROUP"
+  echo "To check:       $0 --status"
+  exit 0
+fi
+
+# ACTION == "run"
+run_week() {
+  local week_idx=$1
+  local from_date to_date
+  read -r from_date to_date <<< "${WEEKS[$week_idx]}"
+  local week_num=$((week_idx + 1))
+  local week_padded
+  week_padded=$(printf "%02d" "$week_num")
+  local job_name="backfill-florida-${AGE_GROUP}-week${week_padded}"
+
+  # Check if job already exists
+  if kubectl get job "$job_name" -n "$NAMESPACE" &>/dev/null; then
+    echo "  [SKIP] $job_name already exists"
+    return
+  fi
+
+  echo "  [RUN] $job_name: $TARGET $from_date to $to_date"
+
+  kubectl apply -f - <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${job_name}
+  namespace: ${NAMESPACE}
+  labels:
+    app: match-scraper-agent
+    task: backfill
+    division: florida
+    age-group: ${AGE_GROUP}
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
+  template:
+    metadata:
+      labels:
+        app: match-scraper-agent
+        task: backfill
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: agent
+          image: ${IMAGE}
+          args:
+            - scrape
+            - --target
+            - ${TARGET}
+            - --from
+            - "${from_date}"
+            - --to
+            - "${to_date}"
+            - --submit
+            - --env
+            - prod
+          envFrom:
+            - configMapRef:
+                name: match-scraper-agent-config
+            - secretRef:
+                name: match-scraper-agent-secret
+          resources:
+            requests:
+              cpu: 200m
+              memory: 1Gi
+            limits:
+              cpu: "1"
+              memory: 2Gi
+YAML
+}
+
+if [[ -n "$WEEK_NUM" ]]; then
+  # Run a single week
+  week_idx=$((WEEK_NUM - 1))
+  if [[ $week_idx -lt 0 || $week_idx -ge ${#WEEKS[@]} ]]; then
+    echo "Invalid week number: $WEEK_NUM (valid: 1-${#WEEKS[@]})"
+    exit 1
+  fi
+  echo "Running backfill week $WEEK_NUM for ${AGE_GROUP^^} Florida HG..."
+  run_week "$week_idx"
+else
+  # Run all weeks
+  echo "Running ALL backfill weeks for ${AGE_GROUP^^} Florida HG..."
+  for i in "${!WEEKS[@]}"; do
+    run_week "$i"
+  done
+fi
+
+echo ""
+echo "Check status: $0 --status"
+echo "View logs:    kubectl logs -n $NAMESPACE -l task=backfill --tail=50 -f"

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -389,6 +389,10 @@ def scrape(
         str | None,
         typer.Option("--to", help="End date (YYYY-MM-DD). Defaults to season end (2026-06-30)."),
     ] = None,
+    submit: Annotated[
+        bool,
+        typer.Option("--submit", help="Submit scraped matches to RabbitMQ queue"),
+    ] = False,
 ) -> None:
     """Scrape matches directly — no LLM, no API key, no proxy needed."""
     import asyncio
@@ -492,3 +496,22 @@ def scrape(
                 f"  {m['match_date']} | {m['home_team']} vs {m['away_team']}"
                 f"{score} [{m['match_status']}]"
             )
+
+    if submit:
+        from src.celery.queue_client import MatchQueueClient
+
+        queue_client = MatchQueueClient(**_queue_client_kwargs(settings))
+        submitted = 0
+        errors = 0
+        for match_dict in built:
+            try:
+                queue_client.submit_match(match_dict)
+                submitted += 1
+            except Exception as exc:
+                errors += 1
+                logger.warning(
+                    "scrape.submit_error",
+                    match=f"{match_dict['home_team']} vs {match_dict['away_team']}",
+                    error=str(exc),
+                )
+        typer.echo(f"\nSubmitted {submitted} matches to queue ({errors} errors).")


### PR DESCRIPTION
## Summary
- Add `--submit` flag to `scrape` CLI command — enables direct queue submission without using the LLM agent (zero token cost)
- Add `scripts/backfill-florida.sh` — orchestrates weekly backfill K3s Jobs for Florida HG fall 2025 (Aug 28 - Dec 1)
- Add sample K3s Job manifest at `k3s/backfill/florida-u14-week01.yaml`

## Usage

```bash
# See the backfill plan
./scripts/backfill-florida.sh

# Run week 1 only (U14 Florida, 2025-08-28 to 2025-09-04)
./scripts/backfill-florida.sh --run --week 1 --age u14

# Check job status
./scripts/backfill-florida.sh --status

# Run U13 after U14 is verified
./scripts/backfill-florida.sh --run --week 1 --age u13
```

## Backfill Execution Plan
Start with 1 week / 1 age group, verify matches appear in MT, then continue:
1. `--run --week 1 --age u14` → review in MT
2. If good, run remaining weeks for U14
3. Then repeat for U13

## Test plan
- [x] All 16 tests pass
- [x] Ruff lint and format checks pass
- [ ] Manual: run week 1 backfill after Docker image rebuild

## Depends on
- match-scraper [#55](https://github.com/silverbeer/match-scraper/pull/55) (merged) — pagination dedup fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)