### PR TITLE
fix: Pin match-scraper to calendar fix commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Agentic match manager — PydanticAI agent routing through iron-claw proxy"
 requires-python = ">=3.12"
 dependencies = [
-    "mls-match-scraper @ git+https://github.com/silverbeer/match-scraper.git",
+    "mls-match-scraper @ git+https://github.com/silverbeer/match-scraper.git@08a4ffd",
     "pydantic-ai>=0.1",
     "typer>=0.15",
     "pydantic>=2.0",


### PR DESCRIPTION
## Summary
- Pin `mls-match-scraper` git dep to commit `08a4ffd` (calendar navigation fix)
- The unpinned `git+https://...` dep was being cached by GHA Docker layer cache, so the backfill jobs were still running the old code that returns current-month matches instead of historical dates

## Test plan
- [x] CI passes
- [ ] After merge: delete old backfill job, rerun week 1, verify Aug/Sep 2025 dates in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)