### PR TITLE
feat: Add get_match_status tool for MT-aware scraping

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,5 +1,5 @@
 You are an agentic match data manager for youth soccer (MLS Next).
-Each run, you decide what actions to take based on the current date.
+Each run, you decide what actions to take based on MT's current state.
 
 ## Our Club
 
@@ -10,10 +10,11 @@ app plays for the U14 HG IFA team. "IFA" is the club name in the MT system.
 
 - **HG** = Homegrown = MLS Next Allstate Homegrown Division Schedule page
 - **Academy** = MLS Next Academy Division Schedule page
+- **MT** = MissingTable — our match database backend
 
-## What to Scrape
+## Scraping Targets
 
-You MUST scrape all five of these targets, in priority order:
+You MUST handle all five targets, in priority order:
 
 1. **U14 HG Northeast** (top priority — this is our team)
 2. **U13 HG Northeast**
@@ -33,14 +34,24 @@ until the end.
 The spring season runs **March 1 through June 30**. Matches outside this
 window are not expected.
 
-## Goal: Load Schedules Fast
+## Decision Flow
 
-MT fans are eager to see upcoming match schedules. The top priority is
-getting ALL scheduled matches loaded into MT as soon as possible.
+1. Call `get_today_info()` — learn the date and day of week.
+2. Call `get_match_status()` — see what MT already has for each target.
+3. For each target, decide your strategy based on MT status:
 
-On each run, scrape the FULL remaining season (from today through June 30)
-for each target. This ensures every newly published match gets picked up
-immediately. Do NOT scrape week-by-week — cast a wide net.
+   - **0 matches in MT** → full-season sync (highest priority, scrape today through Jun 30)
+   - **needs_score > 0** → scrape from a few days before the earliest unscored
+     match through Jun 30 to pick up late-posted scores AND new schedule changes
+   - **Fully up to date** (no needs_score, all future matches present) → skip,
+     or do a light scrape if it's been a while since last played date
+   - **Monday 02:00 UTC run** → full-season sync for ALL targets regardless
+     of status (weekly catch-all for schedule changes)
+
+4. Scrape → submit per target as needed.
+5. If `get_match_status()` fails → fall back to full-season scrape for all
+   targets (current behavior, safe default).
+6. Summarize findings across all targets.
 
 ## Schedule & Scoring Awareness
 
@@ -55,14 +66,3 @@ immediately. Do NOT scrape week-by-week — cast a wide net.
 **Important:** Scrape one target at a time. Call scrape_matches, then
 submit_matches, then move to the next target. Do NOT call multiple
 scrape_matches in parallel.
-
-1. Call get_today_info to learn the date and day of week.
-2. Choose your date range:
-   - **Primary range**: today through **2026-06-30** (end of season) to
-     capture all upcoming scheduled matches.
-   - **Lookback**: If today is Mon–Wed, ALSO scrape last weekend (Fri–Sun)
-     in a separate call to pick up late-posted scores.
-3. For each of the 3 targets, call scrape_matches with the primary range.
-4. After each scrape, call submit_matches if matches were found.
-5. If a lookback is needed, repeat for the lookback range.
-6. Summarize findings across all targets.

--- a/src/agent/core.py
+++ b/src/agent/core.py
@@ -10,7 +10,7 @@ from pydantic_ai.providers.anthropic import AnthropicProvider
 
 from agent.deps import AgentDeps
 from agent.result import AgentResult
-from agent.tools import get_today_info, scrape_matches, submit_matches
+from agent.tools import get_match_status, get_today_info, scrape_matches, submit_matches
 from config.settings import AgentSettings
 
 AGENT_MD = Path(__file__).resolve().parents[2] / "agent.md"
@@ -50,7 +50,7 @@ def create_agent(settings: AgentSettings) -> Agent[AgentDeps, AgentResult]:
         output_type=AgentResult,
         deps_type=AgentDeps,
         system_prompt=_load_system_prompt(),
-        tools=[get_today_info, scrape_matches, submit_matches],
+        tools=[get_today_info, get_match_status, scrape_matches, submit_matches],
         retries=1,
         max_concurrency=1,  # One Chromium at a time — fits pod resources, polite to MLS
     )

--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -49,6 +49,67 @@ def get_today_info(ctx: RunContext[AgentDeps]) -> str:
     )
 
 
+async def get_match_status(ctx: RunContext[AgentDeps]) -> str:
+    """Check what match data MT already has for the current season.
+
+    Queries the MT backend for match counts grouped by age group, league,
+    and division. Use this to decide what needs scraping vs what's up to date.
+    """
+    import httpx
+
+    settings = ctx.deps.settings
+    season = _current_season()
+    url = f"{settings.missing_table_api_url}/api/agent/match-summary"
+
+    logger.info("tool.get_match_status", url=url, season=season)
+
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.get(
+                url,
+                params={"season": season},
+                headers={"Authorization": f"Bearer {settings.missing_table_api_key}"},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+    except Exception as exc:
+        logger.warning("tool.get_match_status.failed", error=str(exc))
+        return "Could not reach MT backend. Falling back to full-season scrape."
+
+    targets = data.get("targets", [])
+    if not targets:
+        return f"MT has no matches for {season}. All targets need full-season sync."
+
+    lines = [f"MT Status ({season} season):\n"]
+    for t in targets:
+        status_parts = []
+        for s in ("played", "scheduled", "tbd", "postponed", "cancelled"):
+            count = t["by_status"].get(s, 0)
+            if count:
+                status_parts.append(f"{count} {s}")
+
+        needs = t.get("needs_score", 0)
+        if needs:
+            status_parts.append(f"{needs} awaiting scores")
+
+        summary = ", ".join(status_parts) if status_parts else "no matches"
+        line = f"{t['age_group']} {t['league']} {t['division']}: {t['total']} matches ({summary})"
+
+        details = []
+        dr = t.get("date_range", {})
+        if dr.get("earliest") and dr.get("latest"):
+            details.append(f"Dates: {dr['earliest']} - {dr['latest']}")
+        if t.get("last_played_date"):
+            details.append(f"Last played: {t['last_played_date']}")
+        if details:
+            line += f"\n  {' | '.join(details)}"
+
+        lines.append(line)
+
+    logger.info("tool.get_match_status.done", target_count=len(targets))
+    return "\n".join(lines)
+
+
 # Season end date — enforced as a floor for end_date so the LLM can't
 # accidentally use a shorter range than the full remaining season.
 SEASON_END = date(2026, 6, 30)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from pydantic_ai import RunContext
 
 from agent.deps import AgentDeps
-from agent.tools import get_today_info, scrape_matches, submit_matches
+from agent.tools import get_match_status, get_today_info, scrape_matches, submit_matches
 from config.settings import AgentSettings
 
 
@@ -207,3 +207,83 @@ class TestSubmitMatches:
         result = asyncio.run(submit_matches(ctx))
         assert "Submitted 2 matches" in result
         assert "1 errors" in result
+
+
+class TestGetMatchStatus:
+    def test_returns_summary(self) -> None:
+        deps = _make_deps()
+        ctx = _make_ctx(deps)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "season": "2025-26",
+            "generated_at": "2026-03-08T14:00:00Z",
+            "targets": [
+                {
+                    "age_group": "U14",
+                    "league": "Homegrown",
+                    "division": "Northeast",
+                    "total": 92,
+                    "by_status": {"played": 45, "scheduled": 40, "tbd": 5, "postponed": 2},
+                    "needs_score": 5,
+                    "date_range": {"earliest": "2026-03-01", "latest": "2026-06-28"},
+                    "last_played_date": "2026-03-07",
+                },
+            ],
+        }
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            result = asyncio.run(get_match_status(ctx))
+
+        assert "MT Status" in result
+        assert "U14 Homegrown Northeast" in result
+        assert "92 matches" in result
+        assert "45 played" in result
+        assert "5 awaiting scores" in result
+
+    def test_fallback_on_error(self) -> None:
+        deps = _make_deps()
+        ctx = _make_ctx(deps)
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(side_effect=Exception("connection refused"))
+            mock_client_cls.return_value = mock_client
+
+            result = asyncio.run(get_match_status(ctx))
+
+        assert "Could not reach MT backend" in result
+        assert "full-season scrape" in result
+
+    def test_empty_targets(self) -> None:
+        deps = _make_deps()
+        ctx = _make_ctx(deps)
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "season": "2025-26",
+            "targets": [],
+        }
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            result = asyncio.run(get_match_status(ctx))
+
+        assert "no matches" in result.lower()
+        assert "full-season sync" in result


### PR DESCRIPTION
## Summary
- New `get_match_status` agent tool that calls MT's `/api/agent/match-summary` endpoint
- Returns human-readable summary of what MT already has per scraping target
- Falls back gracefully if MT is unreachable (full-season scrape, current behavior)
- Updated system prompt (`agent.md`) with new decision flow: check MT status → scrape only what's needed
- 3 new tests for the tool (success, error fallback, empty targets)

## Context
Depends on silverbeer/missing-table PR (match-summary endpoint). The agent's fallback behavior ensures it works even before the MT endpoint is deployed.

## Test plan
- [x] All 38 tests pass: `cd tests && uv run pytest -v`
- [x] Ruff lint clean
- [ ] After MT endpoint deployed: `uv run match-scraper-agent run --dry-run` to verify targeted scraping decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)