### PR TITLE
fix: Point agent at prod MT backend

### DIFF
--- a/k3s/match-scraper-agent/configmap.yaml
+++ b/k3s/match-scraper-agent/configmap.yaml
@@ -11,7 +11,7 @@ data:
   AGENT_LEAGUE: "Homegrown"
   AGENT_AGE_GROUP: "U14"
   AGENT_DIVISION: "Northeast"
-  AGENT_MISSING_TABLE_API_URL: "http://missing-table-backend.missing-table.svc.cluster.local:8000"
+  AGENT_MISSING_TABLE_API_URL: "https://api.missingtable.com"
   AGENT_PROXY_ENABLED: "true"
   AGENT_MIN_TOKEN_BUDGET: "5000"
   AGENT_DRY_RUN: "false"


### PR DESCRIPTION
## Summary
- Switch `AGENT_MISSING_TABLE_API_URL` from in-cluster service URL to `https://api.missingtable.com`
- The in-cluster `missing-table-backend` pod has been in `ImagePullBackOff` for 53 days
- This unblocks the `get_match_status` tool so the agent can make targeted scraping decisions

## Test plan
- [x] Dry run verified: `get_match_status` connected, returned 9 target groups, agent reduced scrape from 502 → 430 matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)