### PR TITLE
feat: Report times in EDT + weekend scores section

### DIFF
--- a/src/utils/report.py
+++ b/src/utils/report.py
@@ -190,8 +190,7 @@ def _weekend_scores_section(now: datetime, matches: list[dict[str, Any]]) -> lis
     scored = [
         m
         for m in matches
-        if _is_last_weekend(m.get("match_date", ""), now)
-        and m.get("match_status") == "completed"
+        if _is_last_weekend(m.get("match_date", ""), now) and m.get("match_status") == "completed"
     ]
     if not scored:
         return []

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -128,7 +128,6 @@ class TestBuildReport:
         assert "Awaiting Scores" in report
         assert "NYCFC" in report
 
-
     def test_weekend_scores_shown_on_monday(self) -> None:
         now = datetime(2026, 3, 9, 14, 0, tzinfo=UTC)  # Monday
         matches = [


### PR DESCRIPTION
## Summary
- Display header and next-run times in US/Eastern (EDT/EST) instead of UTC
- Add Weekend Scores section (Mon–Wed) showing completed match results with actual scores
- Weekend Matches Awaiting Scores section continues to show missing scores

## Test plan
- [x] All 24 report tests pass
- [x] Ruff lint clean
- [ ] Verify next Telegram report shows EDT times
- [ ] Verify weekend scores appear on Monday report

🤖 Generated with [Claude Code](https://claude.com/claude-code)