### PR TITLE
feat: Add run journal for cross-run agent memory

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -61,6 +61,21 @@ window are not expected.
 - A match with status "tbd" means it was played but the score hasn't been
   posted yet. This is normal — do NOT treat it as an error.
 
+## Run Journal
+
+At the start of each run you may receive a "Previous Run Journal" block in
+your prompt. This tells you what happened last time — matches found, scores
+status, and your own summary. Use it to:
+
+- Prioritize targets that had missing scores last run
+- Notice if a previous run had errors and may need retry
+- Track score posting progress across runs (e.g., "last run had 4 missing
+  scores, now only 1 remains")
+- Avoid unnecessary full scrapes if the last run recently synced everything
+
+If no journal is present, this is either the first run or the journal is
+disabled — proceed with normal decision flow.
+
 ## Scraping Strategy
 
 **Important:** Scrape one target at a time. Call scrape_matches, then

--- a/k3s/deploy.sh
+++ b/k3s/deploy.sh
@@ -77,6 +77,7 @@ kubectl rollout status deployment/rabbitmq -n match-scraper --timeout=60s
 
 echo ""
 echo "Applying match-scraper-agent..."
+kubectl apply -f "$SCRIPT_DIR/match-scraper-agent/pvc.yaml"
 kubectl apply -f "$SCRIPT_DIR/match-scraper-agent/configmap.yaml"
 kubectl apply -f "$SECRET_FILE"
 kubectl apply -f "$SCRIPT_DIR/match-scraper-agent/cronjob.yaml"

--- a/k3s/match-scraper-agent/configmap.yaml
+++ b/k3s/match-scraper-agent/configmap.yaml
@@ -14,5 +14,6 @@ data:
   AGENT_MISSING_TABLE_API_URL: "https://api.missingtable.com"
   AGENT_PROXY_ENABLED: "true"
   AGENT_MIN_TOKEN_BUDGET: "5000"
+  AGENT_JOURNAL_PATH: "/data/agent-state/journal.json"
   AGENT_DRY_RUN: "false"
   AGENT_JSON_LOGS: "true"

--- a/k3s/match-scraper-agent/cronjob.yaml
+++ b/k3s/match-scraper-agent/cronjob.yaml
@@ -24,6 +24,9 @@ spec:
                     name: match-scraper-agent-config
                 - secretRef:
                     name: match-scraper-agent-secret
+              volumeMounts:
+                - name: agent-state
+                  mountPath: /data/agent-state
               resources:
                 requests:
                   cpu: 200m
@@ -31,3 +34,7 @@ spec:
                 limits:
                   cpu: "1"
                   memory: 2Gi
+          volumes:
+            - name: agent-state
+              persistentVolumeClaim:
+                claimName: agent-state

--- a/k3s/match-scraper-agent/pvc.yaml
+++ b/k3s/match-scraper-agent/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: agent-state
+  namespace: match-scraper
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 64Mi

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -336,6 +336,19 @@ def run(
         else:
             user_prompt = "Review today's matches and take appropriate actions."
 
+        # Inject previous run journal into prompt (cross-run memory)
+        journal_context = ""
+        if settings.journal_path:
+            from pathlib import Path
+
+            from utils.journal import format_journal_prompt, read_journal
+
+            prev_journal = read_journal(Path(settings.journal_path))
+            journal_context = format_journal_prompt(prev_journal)
+            if journal_context:
+                user_prompt = f"{journal_context}\n\n{user_prompt}"
+                logger.info("journal.loaded", run_id=prev_journal.run_id if prev_journal else None)
+
         result = agent.run_sync(user_prompt, deps=deps)
     except Exception as exc:
         message, known = _classify_error(exc, settings.proxy_base_url)
@@ -361,6 +374,22 @@ def run(
         for action in result.output.actions:
             prefix = "[DRY RUN] " if action.dry_run else ""
             typer.echo(f"  {prefix}{action.action}: {action.detail}")
+
+    # Write run journal for next run's context
+    if settings.journal_path:
+        from pathlib import Path
+
+        from utils.journal import build_journal, write_journal
+
+        journal = build_journal(
+            run_id=run_id,
+            result=result,
+            scraped_matches=deps._scraped_matches,
+            submission_errors=deps._submission_errors,
+            target=target,
+            dry_run=settings.dry_run,
+        )
+        write_journal(Path(settings.journal_path), journal)
 
     # Send Telegram summary report
     _send_telegram_report(

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -52,6 +52,9 @@ class AgentSettings(BaseSettings):
     json_logs: bool = False
     log_level: str = "info"
 
+    # Run journal (cross-run memory)
+    journal_path: str = ""
+
     # Telegram notifications (run summary report)
     telegram_bot_token: str = ""
     telegram_chat_id: str = ""

--- a/src/utils/journal.py
+++ b/src/utils/journal.py
@@ -1,0 +1,207 @@
+"""Run journal — lightweight cross-run memory for the agent."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import structlog
+from pydantic import BaseModel
+
+logger = structlog.get_logger()
+
+
+class TargetEntry(BaseModel):
+    """Per-target stats from a single run."""
+
+    target: str
+    matches_found: int = 0
+    matches_submitted: int = 0
+    completed: int = 0
+    missing_scores: int = 0
+    errors: int = 0
+
+
+class RunJournal(BaseModel):
+    """Snapshot of the last agent run, persisted as JSON between runs."""
+
+    timestamp: str  # ISO 8601 UTC
+    run_id: str
+    target: str | None = None
+    dry_run: bool = False
+    agent_summary: str = ""
+    targets: list[TargetEntry] = []
+    total_matches_found: int = 0
+    total_matches_submitted: int = 0
+    weekend_scores_status: str = ""
+    missing_score_matches: list[str] = []
+
+
+def read_journal(path: Path) -> RunJournal | None:
+    """Read the last run journal from disk. Returns None if missing or invalid."""
+    try:
+        return RunJournal.model_validate_json(path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError, Exception) as exc:
+        logger.debug("journal.read_skipped", path=str(path), reason=str(exc))
+        return None
+
+
+def write_journal(path: Path, journal: RunJournal) -> None:
+    """Write the run journal to disk. Never raises."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(journal.model_dump_json(indent=2))
+        logger.info("journal.written", path=str(path))
+    except Exception as exc:
+        logger.warning("journal.write_failed", path=str(path), error=str(exc))
+
+
+def build_journal(
+    *,
+    run_id: str,
+    result: Any,
+    scraped_matches: list[dict[str, Any]],
+    submission_errors: list[dict[str, str]],
+    target: str | None,
+    dry_run: bool,
+    now: datetime | None = None,
+) -> RunJournal:
+    """Build a RunJournal from post-run data."""
+    now = now or datetime.now(tz=UTC)
+
+    # Per-target breakdown
+    targets_map: dict[str, TargetEntry] = {}
+    for m in scraped_matches:
+        label = _target_label(m)
+        entry = targets_map.setdefault(label, TargetEntry(target=label))
+        entry.matches_found += 1
+        if m.get("match_status") == "completed":
+            entry.completed += 1
+        elif _is_past(m.get("match_date", ""), now) and m.get("match_status") != "completed":
+            entry.missing_scores += 1
+
+    for err in submission_errors:
+        label = err.get("target", "unknown")
+        entry = targets_map.setdefault(label, TargetEntry(target=label))
+        entry.errors += 1
+
+    # Submitted counts come from the result totals, distribute proportionally
+    # but for simplicity just set found counts and total submitted
+    for entry in targets_map.values():
+        entry.matches_submitted = entry.matches_found  # approximate per-target
+
+    # Weekend scores status
+    weekend_status = _weekend_status(now, scraped_matches)
+
+    # Missing score match labels
+    missing = [
+        f"{m.get('match_date', '?')} {m.get('home_team', '?')} vs {m.get('away_team', '?')}"
+        f" ({m.get('match_status', '?')})"
+        for m in scraped_matches
+        if _is_past(m.get("match_date", ""), now) and m.get("match_status") != "completed"
+    ]
+
+    return RunJournal(
+        timestamp=now.isoformat(),
+        run_id=run_id,
+        target=target,
+        dry_run=dry_run,
+        agent_summary=result.output.summary,
+        targets=list(targets_map.values()),
+        total_matches_found=result.output.matches_found,
+        total_matches_submitted=result.output.matches_submitted,
+        weekend_scores_status=weekend_status,
+        missing_score_matches=missing,
+    )
+
+
+def format_journal_prompt(journal: RunJournal | None) -> str:
+    """Format a journal as context to prepend to the user prompt."""
+    if journal is None:
+        return ""
+
+    lines = [
+        "--- Previous Run Journal ---",
+        f"Last run: {journal.timestamp} (run_id: {journal.run_id})",
+    ]
+    if journal.target:
+        lines.append(f"Target filter: {journal.target}")
+    if journal.dry_run:
+        lines.append("Mode: DRY RUN")
+
+    lines.append(
+        f"Totals: {journal.total_matches_found} found, {journal.total_matches_submitted} submitted"
+    )
+
+    for t in journal.targets:
+        parts = [f"{t.matches_found} found"]
+        if t.completed:
+            parts.append(f"{t.completed} scored")
+        if t.missing_scores:
+            parts.append(f"{t.missing_scores} missing scores")
+        if t.errors:
+            parts.append(f"{t.errors} errors")
+        lines.append(f"  {t.target}: {', '.join(parts)}")
+
+    if journal.weekend_scores_status:
+        lines.append(f"Weekend scores: {journal.weekend_scores_status}")
+
+    if journal.missing_score_matches:
+        lines.append("Missing scores:")
+        for m in journal.missing_score_matches[:10]:  # cap to avoid bloat
+            lines.append(f"  - {m}")
+        if len(journal.missing_score_matches) > 10:
+            lines.append(f"  ... and {len(journal.missing_score_matches) - 10} more")
+
+    if journal.agent_summary:
+        lines.append(f'Agent said: "{journal.agent_summary}"')
+
+    lines.append("--- End Journal ---")
+    return "\n".join(lines)
+
+
+def _target_label(match: dict[str, Any]) -> str:
+    """Derive a human-readable target label from a match dict."""
+    ag = match.get("age_group", "?")
+    league = match.get("league", "?")
+    div = match.get("division", "?")
+    league_short = "HG" if league == "Homegrown" else "Academy"
+    return f"{ag} {league_short} {div}"
+
+
+def _is_past(match_date: str, now: datetime) -> bool:
+    """Check if a match date is in the past."""
+    try:
+        md = datetime.strptime(match_date, "%Y-%m-%d").date()
+        return md < now.date()
+    except (ValueError, TypeError):
+        return False
+
+
+def _weekend_status(now: datetime, matches: list[dict[str, Any]]) -> str:
+    """Summarize weekend score status."""
+    today = now.date()
+    day = today.weekday()
+    days_since_sunday = (day + 1) % 7
+    last_sunday = today - timedelta(days=days_since_sunday)
+    last_saturday = last_sunday - timedelta(days=1)
+
+    weekend = [m for m in matches if _match_date(m) in (last_saturday, last_sunday)]
+    if not weekend:
+        return "no weekend matches"
+
+    scored = sum(1 for m in weekend if m.get("match_status") == "completed")
+    unscored = len(weekend) - scored
+    if unscored == 0:
+        return "all posted"
+    return f"{unscored} awaiting scores"
+
+
+def _match_date(match: dict[str, Any]) -> Any:
+    """Parse match_date to a date object, or return None."""
+    try:
+        return datetime.strptime(match.get("match_date", ""), "%Y-%m-%d").date()
+    except (ValueError, TypeError):
+        return None

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -1,0 +1,221 @@
+"""Tests for the run journal (cross-run memory)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+from utils.journal import (
+    RunJournal,
+    TargetEntry,
+    build_journal,
+    format_journal_prompt,
+    read_journal,
+    write_journal,
+)
+
+
+def _match(
+    home: str = "IFA",
+    away: str = "Revolution",
+    match_date: str = "2026-03-08",
+    status: str = "completed",
+    home_score: int | None = 2,
+    away_score: int | None = 1,
+    age_group: str = "U14",
+    league: str = "Homegrown",
+    division: str = "Northeast",
+) -> dict:
+    return {
+        "home_team": home,
+        "away_team": away,
+        "match_date": match_date,
+        "match_status": status,
+        "home_score": home_score,
+        "away_score": away_score,
+        "age_group": age_group,
+        "league": league,
+        "division": division,
+    }
+
+
+def _fake_result(
+    summary: str = "All done.",
+    matches_found: int = 5,
+    matches_submitted: int = 5,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        output=SimpleNamespace(
+            summary=summary,
+            matches_found=matches_found,
+            matches_submitted=matches_submitted,
+        )
+    )
+
+
+class TestRunJournalModel:
+    def test_round_trip(self) -> None:
+        journal = RunJournal(
+            timestamp="2026-03-09T14:00:00+00:00",
+            run_id="abc123",
+            agent_summary="Test run",
+            targets=[TargetEntry(target="U14 HG NE", matches_found=10, completed=8)],
+            total_matches_found=10,
+            total_matches_submitted=10,
+        )
+        raw = journal.model_dump_json()
+        restored = RunJournal.model_validate_json(raw)
+        assert restored.run_id == "abc123"
+        assert restored.targets[0].completed == 8
+
+    def test_defaults(self) -> None:
+        journal = RunJournal(timestamp="2026-03-09T14:00:00+00:00", run_id="x")
+        assert journal.target is None
+        assert journal.dry_run is False
+        assert journal.targets == []
+        assert journal.missing_score_matches == []
+
+
+class TestReadJournal:
+    def test_reads_valid_file(self, tmp_path: Path) -> None:
+        p = tmp_path / "journal.json"
+        journal = RunJournal(timestamp="2026-03-09T14:00:00+00:00", run_id="abc")
+        p.write_text(journal.model_dump_json())
+        result = read_journal(p)
+        assert result is not None
+        assert result.run_id == "abc"
+
+    def test_returns_none_for_missing_file(self, tmp_path: Path) -> None:
+        result = read_journal(tmp_path / "nope.json")
+        assert result is None
+
+    def test_returns_none_for_invalid_json(self, tmp_path: Path) -> None:
+        p = tmp_path / "bad.json"
+        p.write_text("not json at all")
+        result = read_journal(p)
+        assert result is None
+
+
+class TestWriteJournal:
+    def test_writes_and_reads_back(self, tmp_path: Path) -> None:
+        p = tmp_path / "journal.json"
+        journal = RunJournal(timestamp="2026-03-09T14:00:00+00:00", run_id="xyz")
+        write_journal(p, journal)
+        restored = read_journal(p)
+        assert restored is not None
+        assert restored.run_id == "xyz"
+
+    def test_creates_parent_dirs(self, tmp_path: Path) -> None:
+        p = tmp_path / "nested" / "deep" / "journal.json"
+        journal = RunJournal(timestamp="2026-03-09T14:00:00+00:00", run_id="nested")
+        write_journal(p, journal)
+        assert p.exists()
+
+    def test_overwrites_existing(self, tmp_path: Path) -> None:
+        p = tmp_path / "journal.json"
+        write_journal(p, RunJournal(timestamp="t1", run_id="first"))
+        write_journal(p, RunJournal(timestamp="t2", run_id="second"))
+        result = read_journal(p)
+        assert result is not None
+        assert result.run_id == "second"
+
+
+class TestBuildJournal:
+    def test_basic(self) -> None:
+        now = datetime(2026, 3, 9, 14, 0, tzinfo=UTC)  # Monday
+        matches = [
+            _match(match_date="2026-03-07", status="completed"),
+            _match(home="NYCFC", away="Red Bulls", match_date="2026-03-08", status="scheduled"),
+        ]
+        journal = build_journal(
+            run_id="abc123",
+            result=_fake_result(),
+            scraped_matches=matches,
+            submission_errors=[],
+            target="u14-hg",
+            dry_run=False,
+            now=now,
+        )
+        assert journal.run_id == "abc123"
+        assert journal.target == "u14-hg"
+        assert journal.total_matches_found == 5
+        assert len(journal.targets) == 1  # both matches are U14 HG Northeast
+        assert journal.targets[0].completed == 1
+        assert journal.targets[0].missing_scores == 1
+
+    def test_weekend_status(self) -> None:
+        now = datetime(2026, 3, 9, 14, 0, tzinfo=UTC)  # Monday
+        matches = [
+            _match(match_date="2026-03-07", status="completed"),
+            _match(match_date="2026-03-08", status="scheduled"),
+        ]
+        journal = build_journal(
+            run_id="x",
+            result=_fake_result(),
+            scraped_matches=matches,
+            submission_errors=[],
+            target=None,
+            dry_run=False,
+            now=now,
+        )
+        assert "1 awaiting" in journal.weekend_scores_status
+
+    def test_missing_scores_list(self) -> None:
+        now = datetime(2026, 3, 9, 14, 0, tzinfo=UTC)
+        matches = [
+            _match(match_date="2026-03-08", status="tbd", home_score=None, away_score=None),
+        ]
+        journal = build_journal(
+            run_id="x",
+            result=_fake_result(),
+            scraped_matches=matches,
+            submission_errors=[],
+            target=None,
+            dry_run=False,
+            now=now,
+        )
+        assert len(journal.missing_score_matches) == 1
+        assert "IFA vs Revolution" in journal.missing_score_matches[0]
+
+
+class TestFormatJournalPrompt:
+    def test_none_returns_empty(self) -> None:
+        assert format_journal_prompt(None) == ""
+
+    def test_basic_format(self) -> None:
+        journal = RunJournal(
+            timestamp="2026-03-09T14:00:00+00:00",
+            run_id="abc123",
+            agent_summary="Scraped 5 targets.",
+            targets=[TargetEntry(target="U14 HG NE", matches_found=42, completed=38)],
+            total_matches_found=42,
+            total_matches_submitted=42,
+            weekend_scores_status="all posted",
+        )
+        text = format_journal_prompt(journal)
+        assert "Previous Run Journal" in text
+        assert "abc123" in text
+        assert "42 found" in text
+        assert "38 scored" in text
+        assert "all posted" in text
+        assert "Scraped 5 targets" in text
+        assert "End Journal" in text
+
+    def test_includes_missing_scores(self) -> None:
+        journal = RunJournal(
+            timestamp="t",
+            run_id="x",
+            missing_score_matches=["2026-03-08 IFA vs Revolution (tbd)"],
+        )
+        text = format_journal_prompt(journal)
+        assert "IFA vs Revolution" in text
+
+    def test_caps_missing_scores_at_10(self) -> None:
+        journal = RunJournal(
+            timestamp="t",
+            run_id="x",
+            missing_score_matches=[f"match {i}" for i in range(15)],
+        )
+        text = format_journal_prompt(journal)
+        assert "and 5 more" in text


### PR DESCRIPTION
## Summary
- Add a lightweight JSON journal that persists between CronJob runs on a PVC
- Before each run, the previous journal is read and injected into the user prompt so the LLM knows what happened last time (matches found, scores status, missing scores, its own summary)
- After each run, a new journal overwrites the previous one
- Disabled locally by default (`AGENT_JOURNAL_PATH` empty), enabled in prod via configmap

## Files
- `src/utils/journal.py` — RunJournal model, read/write/build/format
- `src/config/settings.py` — `AGENT_JOURNAL_PATH` setting
- `src/cli/main.py` — read journal → run agent → write journal
- `agent.md` — Run Journal section for LLM awareness
- `k3s/match-scraper-agent/pvc.yaml` — 64Mi PVC for agent state
- `k3s/match-scraper-agent/cronjob.yaml` — volume mount
- `k3s/match-scraper-agent/configmap.yaml` — sets journal path
- `k3s/deploy.sh` — applies PVC manifest
- `tests/test_journal.py` — 15 tests

## Test plan
- [x] 58 tests pass (15 new journal tests + 43 existing)
- [x] Ruff lint and format clean
- [ ] Deploy to K3s and verify journal.json created after first run
- [ ] Verify second run prompt includes journal context

🤖 Generated with [Claude Code](https://claude.com/claude-code)