### PR TITLE
feat: Day-of-week aware scrape planner

### DIFF
--- a/src/agent/planner.py
+++ b/src/agent/planner.py
@@ -1,4 +1,12 @@
-"""Deterministic scrape planner — replaces LLM decision-making."""
+"""Deterministic scrape planner — day-of-week aware strategy.
+
+Schedule logic:
+  Mon-Wed: Score sync (Fri→Mon window) if scores are missing, else skip.
+  Thu-Fri: Schedule check for upcoming weekend (after 16 UTC), else skip.
+  Sat-Sun: Score sync (Fri→Mon window) — always scrape, scores are posting.
+
+All scrapes use tight Friday-to-Monday windows. No full-season scrapes.
+"""
 
 from __future__ import annotations
 
@@ -11,13 +19,14 @@ from pydantic import BaseModel
 
 logger = structlog.get_logger()
 
-# Score-sync lookback: scrape this many days before the earliest unscored match
-_SCORE_SYNC_LOOKBACK_DAYS = 3
+# Hour threshold for Thu/Fri schedule checks (UTC)
+_SCHEDULE_CHECK_HOUR = 16
 
 
 class ScrapeAction(StrEnum):
     FULL_SYNC = "full_sync"
     SCORE_SYNC = "score_sync"
+    SCHEDULE_CHECK = "schedule_check"
     SKIP = "skip"
 
 
@@ -41,9 +50,26 @@ class RunPlan(BaseModel):
     mt_api_status: str = ""  # "ok", "failed:<reason>", "empty"
 
 
-def is_weekly_sync_run(now: datetime) -> bool:
-    """Monday 02:00-03:00 UTC = weekly full sync window."""
-    return now.weekday() == 0 and now.hour in (2, 3)
+def _weekend_window(today: date) -> tuple[date, date]:
+    """Compute the Friday-to-Monday window for the relevant weekend.
+
+    Mon-Wed: last weekend (previous Fri→Mon).
+    Thu-Fri: upcoming weekend (next Fri→Mon).
+    Sat-Sun: current weekend (this Fri→Mon).
+    """
+    wd = today.weekday()  # 0=Mon, 6=Sun
+
+    if wd in (0, 1, 2):  # Mon-Wed → last weekend
+        friday = today - timedelta(days=wd + 3)
+        monday = today - timedelta(days=wd)
+    elif wd in (3, 4):  # Thu-Fri → upcoming weekend
+        friday = today + timedelta(days=4 - wd)
+        monday = friday + timedelta(days=3)
+    else:  # Sat-Sun → current weekend
+        friday = today - timedelta(days=wd - 4)
+        monday = friday + timedelta(days=3)
+
+    return friday, monday
 
 
 def _target_label(cfg: dict[str, str]) -> str:
@@ -109,19 +135,20 @@ def fetch_mt_status(
 def compute_scrape_plan(
     mt_targets: list[dict[str, Any]],
     target_configs: dict[str, dict[str, str]],
-    today: date,
-    season_end: date,
-    is_weekly: bool,
+    now: datetime,
 ) -> RunPlan:
-    """Compute a deterministic scrape plan for all non-IFA targets.
+    """Compute a day-of-week aware scrape plan for all non-IFA targets.
 
     Args:
         mt_targets: Target dicts from the MT API response.
         target_configs: The _TARGET_SCRAPER_CONFIG dict from main.py.
-        today: Today's date.
-        season_end: Season end date (SEASON_END constant).
-        is_weekly: True for the Monday 02:00 UTC weekly full-sync run.
+        now: Current UTC datetime (used for day-of-week and hour).
     """
+    today = now.date()
+    weekday = now.weekday()  # 0=Mon, 6=Sun
+    hour = now.hour
+    friday, monday = _weekend_window(today)
+
     # Build lookup: (age_group, league, division) → MT target data
     mt_lookup: dict[tuple[str, str, str], dict[str, Any]] = {}
     for t in mt_targets:
@@ -137,28 +164,15 @@ def compute_scrape_plan(
         lookup_key = _cfg_key(cfg)
         mt_data = mt_lookup.get(lookup_key)
 
-        if is_weekly:
-            plans.append(
-                ScrapePlan(
-                    target_key=target_key,
-                    target_label=label,
-                    action=ScrapeAction.FULL_SYNC,
-                    start_date=today,
-                    end_date=season_end,
-                    reason="Weekly full sync (Monday)",
-                    scraper_params=cfg,
-                )
-            )
-            continue
-
+        # Safety net: MT has no data for this division
         if mt_data is None or mt_data.get("total", 0) == 0:
             plans.append(
                 ScrapePlan(
                     target_key=target_key,
                     target_label=label,
                     action=ScrapeAction.FULL_SYNC,
-                    start_date=today,
-                    end_date=season_end,
+                    start_date=friday,
+                    end_date=monday,
                     reason="No matches in MT — needs initial sync",
                     scraper_params=cfg,
                 )
@@ -166,45 +180,72 @@ def compute_scrape_plan(
             continue
 
         needs_score = mt_data.get("needs_score", 0)
-        if needs_score > 0:
-            last_played = mt_data.get("last_played_date")
-            if last_played:
-                try:
-                    lp = date.fromisoformat(last_played)
-                    start = lp - timedelta(days=_SCORE_SYNC_LOOKBACK_DAYS)
-                except ValueError:
-                    start = today
-            else:
-                start = today
+        total = mt_data.get("total", 0)
+        last_played = mt_data.get("last_played_date", "none")
 
+        if weekday in (0, 1, 2):  # Mon-Wed: score focus
+            if needs_score > 0:
+                plans.append(
+                    ScrapePlan(
+                        target_key=target_key,
+                        target_label=label,
+                        action=ScrapeAction.SCORE_SYNC,
+                        start_date=friday,
+                        end_date=monday,
+                        reason=f"{needs_score} match(es) awaiting scores",
+                        scraper_params=cfg,
+                    )
+                )
+            else:
+                plans.append(
+                    ScrapePlan(
+                        target_key=target_key,
+                        target_label=label,
+                        action=ScrapeAction.SKIP,
+                        reason=f"Up to date ({total} matches, last played {last_played})",
+                        scraper_params=cfg,
+                    )
+                )
+
+        elif weekday in (3, 4):  # Thu-Fri: schedule check
+            if hour < _SCHEDULE_CHECK_HOUR:
+                plans.append(
+                    ScrapePlan(
+                        target_key=target_key,
+                        target_label=label,
+                        action=ScrapeAction.SKIP,
+                        reason=f"Schedule check runs after {_SCHEDULE_CHECK_HOUR}:00 UTC",
+                        scraper_params=cfg,
+                    )
+                )
+            else:
+                plans.append(
+                    ScrapePlan(
+                        target_key=target_key,
+                        target_label=label,
+                        action=ScrapeAction.SCHEDULE_CHECK,
+                        start_date=friday,
+                        end_date=monday,
+                        reason="Checking upcoming weekend schedule",
+                        scraper_params=cfg,
+                    )
+                )
+
+        else:  # Sat-Sun: score focus, always scrape
             plans.append(
                 ScrapePlan(
                     target_key=target_key,
                     target_label=label,
                     action=ScrapeAction.SCORE_SYNC,
-                    start_date=start,
-                    end_date=season_end,
-                    reason=f"{needs_score} match(es) awaiting scores",
+                    start_date=friday,
+                    end_date=monday,
+                    reason=f"Weekend score sync ({needs_score} awaiting scores)",
                     scraper_params=cfg,
                 )
             )
-            continue
-
-        # Fully up to date
-        total = mt_data.get("total", 0)
-        last_played = mt_data.get("last_played_date", "none")
-        plans.append(
-            ScrapePlan(
-                target_key=target_key,
-                target_label=label,
-                action=ScrapeAction.SKIP,
-                reason=f"Up to date ({total} matches, last played {last_played})",
-                scraper_params=cfg,
-            )
-        )
 
     mt_status = "ok" if mt_targets else ("empty" if mt_targets is not None else "failed")
-    return RunPlan(plans=plans, is_weekly_sync=is_weekly, mt_api_status=mt_status)
+    return RunPlan(plans=plans, mt_api_status=mt_status)
 
 
 def format_plan_prompt(plan: RunPlan) -> str:
@@ -226,7 +267,12 @@ def format_plan_prompt(plan: RunPlan) -> str:
             lines.append("")
             continue
 
-        action_label = "FULL SYNC" if p.action == ScrapeAction.FULL_SYNC else "SCORE SYNC"
+        action_labels = {
+            ScrapeAction.FULL_SYNC: "FULL SYNC",
+            ScrapeAction.SCORE_SYNC: "SCORE SYNC",
+            ScrapeAction.SCHEDULE_CHECK: "SCHEDULE CHECK",
+        }
+        action_label = action_labels.get(p.action, p.action.value.upper())
         lines.append(f"{step}. **{p.target_label}: {action_label}**")
         lines.append(f"   Reason: {p.reason}")
 

--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -148,16 +148,6 @@ async def scrape_matches(
     settings = ctx.deps.settings
     parsed_start = date.fromisoformat(start_date)
     parsed_end = date.fromisoformat(end_date)
-
-    # Guarantee the end date covers the full season regardless of what the LLM passes
-    if parsed_end < SEASON_END:
-        logger.info(
-            "tool.scrape_matches.extend_end_date",
-            requested=end_date,
-            enforced=SEASON_END.isoformat(),
-        )
-        parsed_end = SEASON_END
-
     look_back = (parsed_end - parsed_start).days
 
     config = ScrapingConfig(

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -375,9 +375,8 @@ def run(
                 compute_scrape_plan,
                 fetch_mt_status,
                 format_plan_prompt,
-                is_weekly_sync_run,
             )
-            from agent.tools import SEASON_END, _current_season
+            from agent.tools import _current_season
 
             now_utc = datetime.now(tz=UTC)
             mt_targets, mt_status_str = fetch_mt_status(
@@ -387,22 +386,21 @@ def run(
             )
             deps._mt_status = mt_status_str
 
-            weekly = is_weekly_sync_run(now_utc)
             plan = compute_scrape_plan(
                 mt_targets=mt_targets,
                 target_configs=_TARGET_SCRAPER_CONFIG,
-                today=now_utc.date(),
-                season_end=SEASON_END,
-                is_weekly=weekly,
+                now=now_utc,
             )
             deps._scrape_plan = plan
 
             logger.info(
                 "planner.computed",
-                weekly=weekly,
+                weekday=now_utc.strftime("%A"),
+                hour_utc=now_utc.hour,
                 mt_status=mt_status_str,
                 full_sync=sum(1 for p in plan.plans if p.action.value == "full_sync"),
                 score_sync=sum(1 for p in plan.plans if p.action.value == "score_sync"),
+                schedule_check=sum(1 for p in plan.plans if p.action.value == "schedule_check"),
                 skip=sum(1 for p in plan.plans if p.action.value == "skip"),
             )
 

--- a/src/utils/report.py
+++ b/src/utils/report.py
@@ -72,12 +72,15 @@ def build_report(
     if scrape_plan and hasattr(scrape_plan, "plans"):
         plan_parts = []
         for p in scrape_plan.plans:
-            icon = {"full_sync": "🔄", "score_sync": "🎯", "skip": "⏭️"}.get(p.action.value, "•")
+            icon = {
+                "full_sync": "🔄",
+                "score_sync": "🎯",
+                "schedule_check": "📋",
+                "skip": "⏭️",
+            }.get(p.action.value, "•")
             plan_parts.append(f"  {icon} {escape(p.target_label)}: {escape(p.reason)}")
         if mt_status.startswith("failed:"):
-            lines.append(escape("⚠️ MT status FAILED — full-season fallback"))
-        elif scrape_plan.is_weekly_sync:
-            lines.append(escape("📡 Weekly full sync (Monday)"))
+            lines.append(escape("⚠️ MT status FAILED — fallback scrape"))
         else:
             skipped = sum(1 for p in scrape_plan.plans if p.action.value == "skip")
             active = len(scrape_plan.plans) - skipped
@@ -183,7 +186,9 @@ def _agent_awareness(now: datetime, matches: list[dict[str, Any]]) -> str:
         return escape("🧠 Mid-week — no recent weekend matches found")
 
     # Thu/Fri
-    return escape("🧠 No recent match activity — routine schedule sync")
+    if now.hour >= 16:
+        return escape("🧠 Pre-weekend — checking upcoming schedule")
+    return escape("🧠 Pre-weekend — schedule check runs after 16:00 UTC")
 
 
 def _is_last_weekend(match_date: str, now: datetime) -> bool:

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,4 +1,4 @@
-"""Tests for the deterministic scrape planner."""
+"""Tests for the day-of-week aware scrape planner."""
 
 from __future__ import annotations
 
@@ -7,12 +7,11 @@ from datetime import UTC, date, datetime
 from agent.planner import (
     RunPlan,
     ScrapeAction,
+    ScrapePlan,
+    _weekend_window,
     compute_scrape_plan,
     format_plan_prompt,
-    is_weekly_sync_run,
 )
-
-SEASON_END = date(2026, 6, 30)
 
 # Minimal target configs (mirrors _TARGET_SCRAPER_CONFIG without IFA entries)
 SAMPLE_CONFIGS = {
@@ -44,51 +43,55 @@ def _mt_target(
     }
 
 
-class TestIsWeeklySyncRun:
-    def test_monday_0200_utc(self):
-        # Monday March 9 2026 02:00 UTC
-        dt = datetime(2026, 3, 9, 2, 0, tzinfo=UTC)
-        assert is_weekly_sync_run(dt) is True
+class TestWeekendWindow:
+    def test_monday(self):
+        fri, mon = _weekend_window(date(2026, 3, 9))  # Monday
+        assert fri == date(2026, 3, 6)  # Last Friday
+        assert mon == date(2026, 3, 9)  # Today (Monday)
 
-    def test_monday_0300_utc(self):
-        dt = datetime(2026, 3, 9, 3, 0, tzinfo=UTC)
-        assert is_weekly_sync_run(dt) is True
+    def test_tuesday(self):
+        fri, mon = _weekend_window(date(2026, 3, 10))  # Tuesday
+        assert fri == date(2026, 3, 6)
+        assert mon == date(2026, 3, 9)
 
-    def test_monday_0800_utc(self):
-        dt = datetime(2026, 3, 9, 8, 0, tzinfo=UTC)
-        assert is_weekly_sync_run(dt) is False
+    def test_wednesday(self):
+        fri, mon = _weekend_window(date(2026, 3, 11))  # Wednesday
+        assert fri == date(2026, 3, 6)
+        assert mon == date(2026, 3, 9)
 
-    def test_tuesday_0200_utc(self):
-        dt = datetime(2026, 3, 10, 2, 0, tzinfo=UTC)
-        assert is_weekly_sync_run(dt) is False
+    def test_thursday(self):
+        fri, mon = _weekend_window(date(2026, 3, 12))  # Thursday
+        assert fri == date(2026, 3, 13)  # Upcoming Friday
+        assert mon == date(2026, 3, 16)  # Upcoming Monday
 
-    def test_thursday_1400_utc(self):
-        dt = datetime(2026, 3, 12, 14, 0, tzinfo=UTC)
-        assert is_weekly_sync_run(dt) is False
+    def test_friday(self):
+        fri, mon = _weekend_window(date(2026, 3, 13))  # Friday
+        assert fri == date(2026, 3, 13)  # Today
+        assert mon == date(2026, 3, 16)
+
+    def test_saturday(self):
+        fri, mon = _weekend_window(date(2026, 3, 14))  # Saturday
+        assert fri == date(2026, 3, 13)  # Yesterday (Friday)
+        assert mon == date(2026, 3, 16)
+
+    def test_sunday(self):
+        fri, mon = _weekend_window(date(2026, 3, 15))  # Sunday
+        assert fri == date(2026, 3, 13)
+        assert mon == date(2026, 3, 16)
 
 
 class TestComputeScrapePlan:
-    def test_all_targets_up_to_date_skips(self):
-        mt_targets = [
+    """Test day-of-week scrape planning logic."""
+
+    def _all_scored_mt(self):
+        return [
             _mt_target("U14", "Homegrown", "Northeast", total=105, last_played_date="2026-03-08"),
             _mt_target("U13", "Homegrown", "Northeast", total=100, last_played_date="2026-03-08"),
             _mt_target("U14", "Academy", "New England", total=99, last_played_date="2026-03-07"),
         ]
-        plan = compute_scrape_plan(
-            mt_targets,
-            SAMPLE_CONFIGS,
-            date(2026, 3, 12),
-            SEASON_END,
-            False,
-        )
 
-        assert len(plan.plans) == 3  # excludes u14-hg-ifa
-        for p in plan.plans:
-            assert p.action == ScrapeAction.SKIP
-            assert "Up to date" in p.reason
-
-    def test_needs_score_triggers_score_sync(self):
-        mt_targets = [
+    def _some_unscored_mt(self):
+        return [
             _mt_target(
                 "U14",
                 "Homegrown",
@@ -98,93 +101,130 @@ class TestComputeScrapePlan:
                 last_played_date="2026-03-08",
             ),
             _mt_target("U13", "Homegrown", "Northeast", total=100, last_played_date="2026-03-08"),
-            _mt_target("U14", "Academy", "New England", total=99),
+            _mt_target("U14", "Academy", "New England", total=99, last_played_date="2026-03-07"),
         ]
-        plan = compute_scrape_plan(
-            mt_targets,
-            SAMPLE_CONFIGS,
-            date(2026, 3, 12),
-            SEASON_END,
-            False,
-        )
+
+    # --- Mon-Wed: score focus ---
+
+    def test_monday_all_scored_skips(self):
+        now = datetime(2026, 3, 9, 8, 0, tzinfo=UTC)  # Monday 08:00
+        plan = compute_scrape_plan(self._all_scored_mt(), SAMPLE_CONFIGS, now)
+
+        assert len(plan.plans) == 3  # excludes IFA
+        for p in plan.plans:
+            assert p.action == ScrapeAction.SKIP
+            assert "Up to date" in p.reason
+
+    def test_tuesday_needs_score_triggers_score_sync(self):
+        now = datetime(2026, 3, 10, 14, 0, tzinfo=UTC)  # Tuesday 14:00
+        plan = compute_scrape_plan(self._some_unscored_mt(), SAMPLE_CONFIGS, now)
 
         u14 = next(p for p in plan.plans if p.target_key == "u14-hg")
         assert u14.action == ScrapeAction.SCORE_SYNC
-        assert u14.start_date == date(2026, 3, 5)  # 3 days before last_played
-        assert u14.end_date == SEASON_END
+        assert u14.start_date == date(2026, 3, 6)  # Friday
+        assert u14.end_date == date(2026, 3, 9)  # Monday
         assert "3 match(es) awaiting scores" in u14.reason
 
+        # Others are up to date → skip
+        u13 = next(p for p in plan.plans if p.target_key == "u13-hg")
+        assert u13.action == ScrapeAction.SKIP
+
+    def test_wednesday_all_scored_skips(self):
+        now = datetime(2026, 3, 11, 2, 0, tzinfo=UTC)  # Wednesday 02:00
+        plan = compute_scrape_plan(self._all_scored_mt(), SAMPLE_CONFIGS, now)
+        for p in plan.plans:
+            assert p.action == ScrapeAction.SKIP
+
+    # --- Thu-Fri: schedule check ---
+
+    def test_thursday_before_16_utc_skips(self):
+        now = datetime(2026, 3, 12, 8, 0, tzinfo=UTC)  # Thursday 08:00
+        plan = compute_scrape_plan(self._all_scored_mt(), SAMPLE_CONFIGS, now)
+        for p in plan.plans:
+            assert p.action == ScrapeAction.SKIP
+            assert "16" in p.reason
+
+    def test_thursday_after_16_utc_schedule_check(self):
+        now = datetime(2026, 3, 12, 20, 0, tzinfo=UTC)  # Thursday 20:00
+        plan = compute_scrape_plan(self._all_scored_mt(), SAMPLE_CONFIGS, now)
+        for p in plan.plans:
+            assert p.action == ScrapeAction.SCHEDULE_CHECK
+            assert p.start_date == date(2026, 3, 13)  # Upcoming Friday
+            assert p.end_date == date(2026, 3, 16)  # Upcoming Monday
+
+    def test_friday_at_16_utc_schedule_check(self):
+        now = datetime(2026, 3, 13, 16, 0, tzinfo=UTC)  # Friday 16:00
+        plan = compute_scrape_plan(self._all_scored_mt(), SAMPLE_CONFIGS, now)
+        for p in plan.plans:
+            assert p.action == ScrapeAction.SCHEDULE_CHECK
+            assert p.start_date == date(2026, 3, 13)  # Today (Friday)
+            assert p.end_date == date(2026, 3, 16)
+
+    def test_friday_before_16_utc_skips(self):
+        now = datetime(2026, 3, 13, 14, 0, tzinfo=UTC)  # Friday 14:00
+        plan = compute_scrape_plan(self._all_scored_mt(), SAMPLE_CONFIGS, now)
+        for p in plan.plans:
+            assert p.action == ScrapeAction.SKIP
+
+    # --- Sat-Sun: always score sync ---
+
+    def test_saturday_always_score_syncs(self):
+        now = datetime(2026, 3, 14, 14, 0, tzinfo=UTC)  # Saturday 14:00
+        plan = compute_scrape_plan(self._all_scored_mt(), SAMPLE_CONFIGS, now)
+        for p in plan.plans:
+            assert p.action == ScrapeAction.SCORE_SYNC
+            assert p.start_date == date(2026, 3, 13)  # Friday
+            assert p.end_date == date(2026, 3, 16)  # Monday
+
+    def test_sunday_always_score_syncs(self):
+        now = datetime(2026, 3, 15, 8, 0, tzinfo=UTC)  # Sunday 08:00
+        plan = compute_scrape_plan(self._all_scored_mt(), SAMPLE_CONFIGS, now)
+        for p in plan.plans:
+            assert p.action == ScrapeAction.SCORE_SYNC
+
+    # --- Edge cases ---
+
     def test_missing_from_mt_triggers_full_sync(self):
-        # Only U14 HG exists in MT, U13 and Academy are missing
         mt_targets = [
             _mt_target("U14", "Homegrown", "Northeast", total=105, last_played_date="2026-03-08"),
         ]
-        plan = compute_scrape_plan(
-            mt_targets,
-            SAMPLE_CONFIGS,
-            date(2026, 3, 12),
-            SEASON_END,
-            False,
-        )
+        now = datetime(2026, 3, 10, 8, 0, tzinfo=UTC)  # Tuesday
+        plan = compute_scrape_plan(mt_targets, SAMPLE_CONFIGS, now)
 
         u13 = next(p for p in plan.plans if p.target_key == "u13-hg")
         assert u13.action == ScrapeAction.FULL_SYNC
         assert "No matches in MT" in u13.reason
-
-        academy = next(p for p in plan.plans if p.target_key == "u14-academy")
-        assert academy.action == ScrapeAction.FULL_SYNC
+        assert u13.start_date == date(2026, 3, 6)  # Uses weekend window
+        assert u13.end_date == date(2026, 3, 9)
 
     def test_zero_total_triggers_full_sync(self):
         mt_targets = [
             _mt_target("U14", "Homegrown", "Northeast", total=0),
         ]
-        plan = compute_scrape_plan(
-            mt_targets,
-            SAMPLE_CONFIGS,
-            date(2026, 3, 12),
-            SEASON_END,
-            False,
-        )
+        now = datetime(2026, 3, 14, 8, 0, tzinfo=UTC)  # Saturday
+        plan = compute_scrape_plan(mt_targets, SAMPLE_CONFIGS, now)
 
         u14 = next(p for p in plan.plans if p.target_key == "u14-hg")
         assert u14.action == ScrapeAction.FULL_SYNC
 
-    def test_weekly_sync_overrides_all(self):
-        mt_targets = [
-            _mt_target("U14", "Homegrown", "Northeast", total=105, last_played_date="2026-03-08"),
-            _mt_target("U13", "Homegrown", "Northeast", total=100, last_played_date="2026-03-08"),
-            _mt_target("U14", "Academy", "New England", total=99, last_played_date="2026-03-07"),
-        ]
-        plan = compute_scrape_plan(mt_targets, SAMPLE_CONFIGS, date(2026, 3, 9), SEASON_END, True)
-
-        assert plan.is_weekly_sync is True
-        for p in plan.plans:
-            assert p.action == ScrapeAction.FULL_SYNC
-            assert "Weekly" in p.reason
-
     def test_empty_mt_response_full_sync_all(self):
-        plan = compute_scrape_plan([], SAMPLE_CONFIGS, date(2026, 3, 12), SEASON_END, False)
-
+        now = datetime(2026, 3, 12, 8, 0, tzinfo=UTC)  # Thursday
+        plan = compute_scrape_plan([], SAMPLE_CONFIGS, now)
         for p in plan.plans:
             assert p.action == ScrapeAction.FULL_SYNC
 
     def test_ifa_targets_excluded(self):
-        plan = compute_scrape_plan([], SAMPLE_CONFIGS, date(2026, 3, 12), SEASON_END, False)
+        now = datetime(2026, 3, 12, 8, 0, tzinfo=UTC)
+        plan = compute_scrape_plan([], SAMPLE_CONFIGS, now)
         keys = [p.target_key for p in plan.plans]
         assert "u14-hg-ifa" not in keys
 
     def test_academy_conference_mapping(self):
-        """Academy targets use conference in config but division in MT response."""
         mt_targets = [
             _mt_target("U14", "Academy", "New England", total=99, last_played_date="2026-03-07"),
         ]
-        plan = compute_scrape_plan(
-            mt_targets,
-            SAMPLE_CONFIGS,
-            date(2026, 3, 12),
-            SEASON_END,
-            False,
-        )
+        now = datetime(2026, 3, 9, 8, 0, tzinfo=UTC)  # Monday
+        plan = compute_scrape_plan(mt_targets, SAMPLE_CONFIGS, now)
 
         academy = next(p for p in plan.plans if p.target_key == "u14-academy")
         assert academy.action == ScrapeAction.SKIP
@@ -194,19 +234,19 @@ class TestFormatPlanPrompt:
     def test_contains_scrape_params(self):
         plan = RunPlan(
             plans=[
-                {
-                    "target_key": "u14-hg",
-                    "target_label": "U14 Homegrown Northeast",
-                    "action": ScrapeAction.FULL_SYNC,
-                    "start_date": date(2026, 3, 12),
-                    "end_date": date(2026, 6, 30),
-                    "reason": "No matches in MT",
-                    "scraper_params": {
+                ScrapePlan(
+                    target_key="u14-hg",
+                    target_label="U14 Homegrown Northeast",
+                    action=ScrapeAction.SCORE_SYNC,
+                    start_date=date(2026, 3, 6),
+                    end_date=date(2026, 3, 9),
+                    reason="3 match(es) awaiting scores",
+                    scraper_params={
                         "age_group": "U14",
                         "league": "Homegrown",
                         "division": "Northeast",
                     },
-                },
+                ),
             ]
         )
         prompt = format_plan_prompt(plan)
@@ -214,17 +254,41 @@ class TestFormatPlanPrompt:
         assert 'division="Northeast"' in prompt
         assert "scrape_matches(" in prompt
         assert "submit_matches()" in prompt
+        assert "SCORE SYNC" in prompt
+
+    def test_schedule_check_format(self):
+        plan = RunPlan(
+            plans=[
+                ScrapePlan(
+                    target_key="u14-hg",
+                    target_label="U14 Homegrown Northeast",
+                    action=ScrapeAction.SCHEDULE_CHECK,
+                    start_date=date(2026, 3, 13),
+                    end_date=date(2026, 3, 16),
+                    reason="Checking upcoming weekend schedule",
+                    scraper_params={
+                        "age_group": "U14",
+                        "league": "Homegrown",
+                        "division": "Northeast",
+                    },
+                ),
+            ]
+        )
+        prompt = format_plan_prompt(plan)
+        assert "SCHEDULE CHECK" in prompt
+        assert "2026-03-13" in prompt
+        assert "2026-03-16" in prompt
 
     def test_skip_shows_reason(self):
         plan = RunPlan(
             plans=[
-                {
-                    "target_key": "u14-hg",
-                    "target_label": "U14 Homegrown Northeast",
-                    "action": ScrapeAction.SKIP,
-                    "reason": "Up to date (105 matches)",
-                    "scraper_params": {},
-                },
+                ScrapePlan(
+                    target_key="u14-hg",
+                    target_label="U14 Homegrown Northeast",
+                    action=ScrapeAction.SKIP,
+                    reason="Up to date (105 matches)",
+                    scraper_params={},
+                ),
             ]
         )
         prompt = format_plan_prompt(plan)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -213,10 +213,15 @@ class TestAgentAwareness:
         result = _agent_awareness(now, matches)
         assert "still awaiting scores" in result
 
-    def test_thursday(self) -> None:
-        now = datetime(2026, 3, 12, 14, 0, tzinfo=UTC)  # Thursday
+    def test_thursday_before_16(self) -> None:
+        now = datetime(2026, 3, 12, 14, 0, tzinfo=UTC)  # Thursday 14:00
         result = _agent_awareness(now, [])
-        assert "routine schedule sync" in result
+        assert "schedule check runs after 16:00 UTC" in result
+
+    def test_thursday_after_16(self) -> None:
+        now = datetime(2026, 3, 12, 20, 0, tzinfo=UTC)  # Thursday 20:00
+        result = _agent_awareness(now, [])
+        assert "checking upcoming schedule" in result
 
 
 class TestIsLastWeekend:


### PR DESCRIPTION
## Summary
- Replace broad today-to-season-end scraping with day-of-week strategy using tight Fri→Mon windows
- Mon-Wed: Score sync only if `needs_score > 0`, else skip — no wasted scrapes when scores are in
- Thu-Fri (≥16 UTC): Schedule check for upcoming weekend to catch late additions/changes
- Sat-Sun: Always score sync — scores are actively posting throughout the weekend
- Remove weekly Monday full sync and SEASON_END enforcement (spring segment is fully loaded)
- Add `SCHEDULE_CHECK` action type with 📋 icon in Telegram reports

## Test plan
- [x] All 84 tests pass (25 planner, 59 others)
- [x] Ruff lint + format clean
- [ ] Verify next prod run uses tight weekend window (check Telegram report)
- [ ] Confirm Thu/Fri runs skip before 16 UTC, schedule check after 20 UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)