### PR TITLE
feat: Add KICKOFF_SYNC for missing kick-off time detection

### DIFF
--- a/src/agent/planner.py
+++ b/src/agent/planner.py
@@ -14,10 +14,14 @@ logger = structlog.get_logger()
 # Score-sync lookback: scrape this many days before the earliest unscored match
 _SCORE_SYNC_LOOKBACK_DAYS = 3
 
+# Kickoff-sync lookahead: check matches within this many days for missing kick-off times
+_KICKOFF_LOOKAHEAD_DAYS = 14
+
 
 class ScrapeAction(StrEnum):
     FULL_SYNC = "full_sync"
     SCORE_SYNC = "score_sync"
+    KICKOFF_SYNC = "kickoff_sync"
     SKIP = "skip"
 
 
@@ -166,6 +170,8 @@ def compute_scrape_plan(
             continue
 
         needs_score = mt_data.get("needs_score", 0)
+        needs_kickoff = mt_data.get("needs_kickoff", 0)
+
         if needs_score > 0:
             last_played = mt_data.get("last_played_date")
             if last_played:
@@ -177,6 +183,10 @@ def compute_scrape_plan(
             else:
                 start = today
 
+            reason_parts = [f"{needs_score} match(es) awaiting scores"]
+            if needs_kickoff > 0:
+                reason_parts.append(f"{needs_kickoff} missing kick-off time(s)")
+
             plans.append(
                 ScrapePlan(
                     target_key=target_key,
@@ -184,7 +194,21 @@ def compute_scrape_plan(
                     action=ScrapeAction.SCORE_SYNC,
                     start_date=start,
                     end_date=season_end,
-                    reason=f"{needs_score} match(es) awaiting scores",
+                    reason=", ".join(reason_parts),
+                    scraper_params=cfg,
+                )
+            )
+            continue
+
+        if needs_kickoff > 0:
+            plans.append(
+                ScrapePlan(
+                    target_key=target_key,
+                    target_label=label,
+                    action=ScrapeAction.KICKOFF_SYNC,
+                    start_date=today,
+                    end_date=today + timedelta(days=_KICKOFF_LOOKAHEAD_DAYS),
+                    reason=f"{needs_kickoff} match(es) missing kick-off time",
                     scraper_params=cfg,
                 )
             )
@@ -226,7 +250,11 @@ def format_plan_prompt(plan: RunPlan) -> str:
             lines.append("")
             continue
 
-        action_label = "FULL SYNC" if p.action == ScrapeAction.FULL_SYNC else "SCORE SYNC"
+        action_label = {
+            ScrapeAction.FULL_SYNC: "FULL SYNC",
+            ScrapeAction.SCORE_SYNC: "SCORE SYNC",
+            ScrapeAction.KICKOFF_SYNC: "KICKOFF SYNC",
+        }.get(p.action, p.action.value.upper())
         lines.append(f"{step}. **{p.target_label}: {action_label}**")
         lines.append(f"   Reason: {p.reason}")
 

--- a/src/utils/report.py
+++ b/src/utils/report.py
@@ -72,7 +72,9 @@ def build_report(
     if scrape_plan and hasattr(scrape_plan, "plans"):
         plan_parts = []
         for p in scrape_plan.plans:
-            icon = {"full_sync": "🔄", "score_sync": "🎯", "skip": "⏭️"}.get(p.action.value, "•")
+            icon = {"full_sync": "🔄", "score_sync": "🎯", "kickoff_sync": "⏰", "skip": "⏭️"}.get(
+                p.action.value, "•"
+            )
             plan_parts.append(f"  {icon} {escape(p.target_label)}: {escape(p.reason)}")
         if mt_status.startswith("failed:"):
             lines.append(escape("⚠️ MT status FAILED — full-season fallback"))
@@ -115,6 +117,12 @@ def build_report(
         summary_parts.append(escape(f"{error_count} errors"))
     lines.append(f"*Matches:* {' · '.join(summary_parts)}")
 
+    no_kickoff = sum(
+        1
+        for m in scraped_matches
+        if m.get("match_time") is None and m.get("match_status") in ("scheduled", "tbd")
+    )
+
     status_parts = []
     if completed:
         status_parts.append(escape(f"{completed} completed"))
@@ -122,6 +130,8 @@ def build_report(
         status_parts.append(escape(f"{scheduled} scheduled"))
     if tbd:
         status_parts.append(escape(f"{tbd} tbd"))
+    if no_kickoff:
+        status_parts.append(escape(f"{no_kickoff} no time"))
     if status_parts:
         lines.append(f"  {' · '.join(status_parts)}")
     lines.append("")
@@ -145,6 +155,12 @@ def build_report(
     missing_lines = _missing_scores_section(now, scraped_matches)
     if missing_lines:
         lines.extend(missing_lines)
+        lines.append("")
+
+    # --- Missing Kick-off Times ---
+    kickoff_lines = _missing_kickoff_section(scraped_matches)
+    if kickoff_lines:
+        lines.extend(kickoff_lines)
         lines.append("")
 
     # --- Next Run ---
@@ -272,6 +288,27 @@ def _missing_scores_section(now: datetime, matches: list[dict[str, Any]]) -> lis
                 md = escape(m.get("match_date", "?"))
                 lines.append(f"  • {md} {home} vs {away} — {status}")
 
+    return lines
+
+
+def _missing_kickoff_section(matches: list[dict[str, Any]]) -> list[str]:
+    """Build the missing kick-off times section."""
+    missing = [
+        m
+        for m in matches
+        if m.get("match_time") is None and m.get("match_status") in ("scheduled", "tbd")
+    ]
+    if not missing:
+        return []
+
+    lines: list[str] = []
+    n = len(missing)
+    lines.append(f"*Missing Kick\\-off Times \\({escape(str(n))}\\):*")
+    for m in sorted(missing, key=lambda x: x.get("match_date", "")):
+        md = escape(m.get("match_date", "?"))
+        home = escape(m.get("home_team", "?"))
+        away = escape(m.get("away_team", "?"))
+        lines.append(f"  • {md} {home} vs {away}")
     return lines
 
 

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 
 from agent.planner import (
+    _KICKOFF_LOOKAHEAD_DAYS,
     RunPlan,
     ScrapeAction,
     compute_scrape_plan,
@@ -30,6 +31,7 @@ def _mt_target(
     division: str,
     total: int = 100,
     needs_score: int = 0,
+    needs_kickoff: int = 0,
     last_played_date: str | None = None,
 ) -> dict:
     return {
@@ -38,6 +40,7 @@ def _mt_target(
         "division": division,
         "total": total,
         "needs_score": needs_score,
+        "needs_kickoff": needs_kickoff,
         "by_status": {"scheduled": total},
         "date_range": {"earliest": "2026-03-01", "latest": "2026-06-28"},
         "last_played_date": last_played_date,
@@ -189,6 +192,102 @@ class TestComputeScrapePlan:
         academy = next(p for p in plan.plans if p.target_key == "u14-academy")
         assert academy.action == ScrapeAction.SKIP
 
+    def test_needs_kickoff_triggers_kickoff_sync(self):
+        mt_targets = [
+            _mt_target(
+                "U14",
+                "Homegrown",
+                "Northeast",
+                total=105,
+                needs_score=0,
+                needs_kickoff=3,
+                last_played_date="2026-03-08",
+            ),
+        ]
+        plan = compute_scrape_plan(
+            mt_targets,
+            SAMPLE_CONFIGS,
+            date(2026, 3, 12),
+            SEASON_END,
+            False,
+        )
+
+        u14 = next(p for p in plan.plans if p.target_key == "u14-hg")
+        assert u14.action == ScrapeAction.KICKOFF_SYNC
+        assert "3 match(es) missing kick-off time" in u14.reason
+
+    def test_kickoff_sync_date_range(self):
+        today = date(2026, 3, 12)
+        mt_targets = [
+            _mt_target(
+                "U14",
+                "Homegrown",
+                "Northeast",
+                total=105,
+                needs_kickoff=2,
+                last_played_date="2026-03-08",
+            ),
+        ]
+        plan = compute_scrape_plan(
+            mt_targets,
+            SAMPLE_CONFIGS,
+            today,
+            SEASON_END,
+            False,
+        )
+
+        u14 = next(p for p in plan.plans if p.target_key == "u14-hg")
+        assert u14.start_date == today
+        assert u14.end_date == today + timedelta(days=_KICKOFF_LOOKAHEAD_DAYS)
+
+    def test_needs_score_and_kickoff_merges(self):
+        mt_targets = [
+            _mt_target(
+                "U14",
+                "Homegrown",
+                "Northeast",
+                total=105,
+                needs_score=3,
+                needs_kickoff=2,
+                last_played_date="2026-03-08",
+            ),
+        ]
+        plan = compute_scrape_plan(
+            mt_targets,
+            SAMPLE_CONFIGS,
+            date(2026, 3, 12),
+            SEASON_END,
+            False,
+        )
+
+        u14 = next(p for p in plan.plans if p.target_key == "u14-hg")
+        assert u14.action == ScrapeAction.SCORE_SYNC
+        assert "awaiting scores" in u14.reason
+        assert "missing kick-off" in u14.reason
+
+    def test_needs_kickoff_zero_skips(self):
+        mt_targets = [
+            _mt_target(
+                "U14",
+                "Homegrown",
+                "Northeast",
+                total=105,
+                needs_score=0,
+                needs_kickoff=0,
+                last_played_date="2026-03-08",
+            ),
+        ]
+        plan = compute_scrape_plan(
+            mt_targets,
+            SAMPLE_CONFIGS,
+            date(2026, 3, 12),
+            SEASON_END,
+            False,
+        )
+
+        u14 = next(p for p in plan.plans if p.target_key == "u14-hg")
+        assert u14.action == ScrapeAction.SKIP
+
 
 class TestFormatPlanPrompt:
     def test_contains_scrape_params(self):
@@ -236,3 +335,25 @@ class TestFormatPlanPrompt:
         plan = RunPlan(plans=[])
         prompt = format_plan_prompt(plan)
         assert "Do NOT call get_match_status()" in prompt
+
+    def test_kickoff_sync_format(self):
+        plan = RunPlan(
+            plans=[
+                {
+                    "target_key": "u14-hg",
+                    "target_label": "U14 Homegrown Northeast",
+                    "action": ScrapeAction.KICKOFF_SYNC,
+                    "start_date": date(2026, 3, 12),
+                    "end_date": date(2026, 3, 26),
+                    "reason": "3 match(es) missing kick-off time",
+                    "scraper_params": {
+                        "age_group": "U14",
+                        "league": "Homegrown",
+                        "division": "Northeast",
+                    },
+                },
+            ]
+        )
+        prompt = format_plan_prompt(plan)
+        assert "KICKOFF SYNC" in prompt
+        assert "scrape_matches(" in prompt

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -8,6 +8,7 @@ from utils.report import (
     _agent_awareness,
     _format_delta,
     _is_last_weekend,
+    _missing_kickoff_section,
     _next_scheduled_run,
     _weekend_scores_section,
     build_report,
@@ -21,6 +22,7 @@ def _match(
     status: str = "completed",
     home_score: int | None = 2,
     away_score: int | None = 1,
+    match_time: str | None = "15:00",
 ) -> dict:
     return {
         "home_team": home,
@@ -29,6 +31,7 @@ def _match(
         "match_status": status,
         "home_score": home_score,
         "away_score": away_score,
+        "match_time": match_time,
     }
 
 
@@ -294,3 +297,85 @@ class TestFormatDelta:
         from datetime import timedelta
 
         assert _format_delta(timedelta(minutes=45)) == "45m"
+
+
+class TestMissingKickoff:
+    def test_missing_kickoff_shown(self) -> None:
+        matches = [
+            _match(status="scheduled", home_score=None, away_score=None, match_time=None),
+            _match(
+                home="NYCFC",
+                away="Red Bulls",
+                status="scheduled",
+                home_score=None,
+                away_score=None,
+                match_time=None,
+            ),
+            _match(status="completed", match_time="15:00"),
+        ]
+        lines = _missing_kickoff_section(matches)
+        assert any("Missing Kick\\-off Times" in line for line in lines)
+        assert len(lines) == 3  # header + 2 matches
+
+    def test_no_kickoff_section_when_all_have_times(self) -> None:
+        matches = [
+            _match(status="scheduled", home_score=None, away_score=None, match_time="15:00"),
+            _match(status="completed", match_time="17:00"),
+        ]
+        lines = _missing_kickoff_section(matches)
+        assert lines == []
+
+    def test_no_kickoff_count_in_summary(self) -> None:
+        now = datetime(2026, 3, 8, 14, 0, tzinfo=UTC)
+        matches = [
+            _match(status="scheduled", home_score=None, away_score=None, match_time=None),
+            _match(status="tbd", home_score=None, away_score=None, match_time=None),
+            _match(status="completed", match_time="15:00"),
+        ]
+        report = build_report(
+            result_summary="",
+            actions=[],
+            matches_found=3,
+            matches_submitted=3,
+            scraped_matches=matches,
+            submission_errors=[],
+            env="prod",
+            target=None,
+            dry_run=False,
+            now=now,
+        )
+        assert "no time" in report
+
+    def test_kickoff_plan_icon(self) -> None:
+        from datetime import date
+
+        from agent.planner import RunPlan, ScrapeAction, ScrapePlan
+
+        now = datetime(2026, 3, 12, 14, 0, tzinfo=UTC)
+        plan = RunPlan(
+            plans=[
+                ScrapePlan(
+                    target_key="u14-hg",
+                    target_label="U14 Homegrown Northeast",
+                    action=ScrapeAction.KICKOFF_SYNC,
+                    start_date=date(2026, 3, 12),
+                    end_date=date(2026, 3, 26),
+                    reason="3 missing kick-off times",
+                    scraper_params={},
+                ),
+            ]
+        )
+        report = build_report(
+            result_summary="",
+            actions=[],
+            matches_found=0,
+            matches_submitted=0,
+            scraped_matches=[],
+            submission_errors=[],
+            env="prod",
+            target=None,
+            dry_run=False,
+            scrape_plan=plan,
+            now=now,
+        )
+        assert "⏰" in report


### PR DESCRIPTION
## Summary

- Planner reads `needs_kickoff` from the MT `/api/agent/match-summary` endpoint and triggers a new `KICKOFF_SYNC` scrape action (today → today+14d) when matches are missing kick-off times
- When both `needs_score` and `needs_kickoff` are non-zero, `SCORE_SYNC` is used with a combined reason (its date range already covers the kickoff window)
- Report gains a "Missing Kick-off Times" section, "no time" count in the status line, and the ⏰ plan icon
- Backward compatible: `needs_kickoff` defaults to 0 via `.get()`, so this works before and after the MT deploy

## Test plan

- [x] `uv run pytest test_planner.py` — 21 tests pass (5 new)
- [x] `uv run pytest test_report.py` — 28 tests pass (4 new)
- [x] `uv run ruff check && ruff format --check` — clean
- [x] Verified `needs_kickoff` field present in local MT response
- [ ] After MT prod deploy: `uv run match-scraper-agent run --dry-run` confirms KICKOFF_SYNC in plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)