### PR TITLE
fix: Bump mls-match-scraper for division filter fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Agentic match manager — PydanticAI agent routing through iron-claw proxy"
 requires-python = ">=3.12"
 dependencies = [
-    "mls-match-scraper @ git+https://github.com/silverbeer/match-scraper.git@08a4ffd",
+    "mls-match-scraper @ git+https://github.com/silverbeer/match-scraper.git@6582f1c",
     "pydantic-ai>=0.1",
     "typer>=0.15",
     "pydantic>=2.0",


### PR DESCRIPTION
## Summary
- Bumps `mls-match-scraper` from `08a4ffd` to `6582f1c` which fixes the division/conference filter selector (silverbeer/match-scraper#57)
- Division filter was silently failing, returning matches from all divisions nationwide instead of just Northeast/Florida

## Test plan
- [x] Live verified: U16 HG NE scrape returns only Northeast matches
- [ ] Next prod CronJob run shows correct match counts per division

🤖 Generated with [Claude Code](https://claude.com/claude-code)