### PR TITLE
fix: Use linode-block-storage-retain for agent-state PVC

### DIFF
--- a/k3s/match-scraper-agent/pvc.yaml
+++ b/k3s/match-scraper-agent/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: local-path
+  storageClassName: linode-block-storage-retain
   resources:
     requests:
-      storage: 64Mi
+      storage: 1Gi


### PR DESCRIPTION
## Summary
- `local-path` StorageClass doesn't exist on Linode LKE, causing the agent-state PVC to stay Pending
- All CronJob runs failed with `FailedScheduling` for ~23 days (since last node recycle)
- Switch to `linode-block-storage-retain` (matches RabbitMQ PVC) and bump size to 1Gi (Linode minimum)

## Test plan
- [x] PVC created and bound on cluster
- [x] Manual job triggered and completed successfully (566 matches scraped/submitted)
- [x] Telegram report delivered

🤖 Generated with [Claude Code](https://claude.com/claude-code)