### PR TITLE
feat: Add --club filter to scrape CLI command

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -546,6 +546,10 @@ def scrape(
         bool,
         typer.Option("--submit", help="Submit scraped matches to RabbitMQ queue"),
     ] = False,
+    club: Annotated[
+        str | None,
+        typer.Option("--club", help="Filter to a specific club name"),
+    ] = None,
 ) -> None:
     """Scrape matches directly — no LLM, no API key, no proxy needed."""
     import asyncio
@@ -585,7 +589,7 @@ def scrape(
         league=target_cfg.get("league", settings.league),
         division=target_cfg.get("division", settings.division),
         conference=target_cfg.get("conference", ""),
-        club="",
+        club=club or "",
         start_date=start,
         end_date=end,
         look_back_days=(end - start).days,


### PR DESCRIPTION
## Summary
- Exposes the existing `club` filtering from mls-match-scraper as a `--club` CLI flag on the `scrape` command
- Enables targeted per-club backfills to verify match coverage (e.g., `--club "Beachside SC"`)
- No changes to agent tool or library — just wiring up the CLI parameter

## Test plan
- [x] `--club` appears in `scrape --help`
- [ ] Deploy and run backfill with `--club` to verify filtering works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)