### PR TITLE
feat: Add audit module for Northeast HG data-integrity auditing

### DIFF
--- a/k3s/audit/cronjob-audit-process.yaml
+++ b/k3s/audit/cronjob-audit-process.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: match-scraper-audit-process
+  namespace: match-scraper
+spec:
+  schedule: "30 1,5,9,13,17,21 * * *"  # 30 min after audit CronJob
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 600  # lightweight — no Playwright
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: agent
+              image: ghcr.io/silverbeer/match-scraper-agent:latest
+              args: ["audit-process", "--env", "prod"]
+              envFrom:
+                - configMapRef:
+                    name: match-scraper-agent-config
+                - secretRef:
+                    name: match-scraper-agent-secret
+              volumeMounts:
+                - name: agent-state
+                  mountPath: /data/agent-state
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  cpu: "500m"
+                  memory: 512Mi
+          volumes:
+            - name: agent-state
+              persistentVolumeClaim:
+                claimName: agent-state

--- a/k3s/audit/cronjob-audit.yaml
+++ b/k3s/audit/cronjob-audit.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: match-scraper-audit
+  namespace: match-scraper
+spec:
+  schedule: "0 1,5,9,13,17,21 * * *"  # 6x/day, offset from main agent (0 2,8,14,20)
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 1800  # 30 min — same as main agent (Playwright)
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: agent
+              image: ghcr.io/silverbeer/match-scraper-agent:latest
+              args: ["audit", "--env", "prod"]
+              envFrom:
+                - configMapRef:
+                    name: match-scraper-agent-config
+                - secretRef:
+                    name: match-scraper-agent-secret
+              volumeMounts:
+                - name: agent-state
+                  mountPath: /data/agent-state
+              resources:
+                requests:
+                  cpu: 200m
+                  memory: 1Gi
+                limits:
+                  cpu: "1"
+                  memory: 2Gi
+          volumes:
+            - name: agent-state
+              persistentVolumeClaim:
+                claimName: agent-state

--- a/k3s/match-scraper-agent/configmap.yaml
+++ b/k3s/match-scraper-agent/configmap.yaml
@@ -17,3 +17,4 @@ data:
   AGENT_JOURNAL_PATH: "/data/agent-state/journal.json"
   AGENT_DRY_RUN: "false"
   AGENT_JSON_LOGS: "true"
+  AGENT_AUDIT_SEASON_START: "2026-02-01"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ build-backend = "hatchling.build"
 allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/agent", "src/cli", "src/config", "src/utils"]
+packages = ["src/agent", "src/audit", "src/cli", "src/config", "src/utils"]
 
 [tool.ruff]
 line-length = 99

--- a/src/audit/__init__.py
+++ b/src/audit/__init__.py
@@ -1,0 +1,1 @@
+"""Audit module for Northeast HG division match data integrity checks."""

--- a/src/audit/client.py
+++ b/src/audit/client.py
@@ -1,0 +1,126 @@
+"""Async httpx client wrapping all MT audit API calls."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import httpx
+import structlog
+
+from audit.models import AuditEvent, NextTeamResponse
+
+logger = structlog.get_logger()
+
+
+def _headers(api_key: str) -> dict[str, str]:
+    if api_key:
+        return {"Authorization": f"Bearer {api_key}"}
+    return {}
+
+
+async def fetch_next_team(
+    api_url: str,
+    api_key: str,
+    season: str,
+    division: str,
+    league: str,
+) -> NextTeamResponse | None:
+    """Return the next team to audit, or None if all teams are up-to-date this week."""
+    url = f"{api_url}/api/agent/audit/next-team"
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.get(
+            url,
+            params={"season": season, "division": division, "league": league},
+            headers=_headers(api_key),
+        )
+        if resp.status_code == 204:
+            logger.info("audit.client.next_team", status="all_current")
+            return None
+        resp.raise_for_status()
+        data = resp.json()
+    logger.info("audit.client.next_team", team=data.get("team"), age_group=data.get("age_group"))
+    return NextTeamResponse.model_validate(data)
+
+
+async def fetch_mt_matches(
+    api_url: str,
+    api_key: str,
+    age_group: str,
+    league: str,
+    division: str,
+    team: str,
+    season: str,
+) -> list[dict]:
+    """Fetch individual match records for a team from MT."""
+    url = f"{api_url}/api/agent/matches"
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.get(
+            url,
+            params={
+                "age_group": age_group,
+                "league": league,
+                "division": division,
+                "team": team,
+                "season": season,
+            },
+            headers=_headers(api_key),
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    matches = data.get("matches", [])
+    logger.info("audit.client.fetch_mt_matches", team=team, count=len(matches))
+    return matches
+
+
+async def submit_audit_event(
+    api_url: str,
+    api_key: str,
+    event: AuditEvent,
+) -> None:
+    """Submit audit findings (or clean result) for a completed team audit."""
+    url = f"{api_url}/api/agent/audit/events"
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.post(url, json=event.model_dump(), headers=_headers(api_key))
+        resp.raise_for_status()
+    logger.info(
+        "audit.client.submit_event",
+        event_id=event.event_id,
+        findings=len(event.findings),
+    )
+
+
+async def fetch_pending_events(
+    api_url: str,
+    api_key: str,
+    season: str,
+) -> list[AuditEvent]:
+    """Fetch all pending audit events for processing."""
+    url = f"{api_url}/api/agent/audit/events"
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.get(
+            url,
+            params={"status": "pending", "season": season},
+            headers=_headers(api_key),
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    events = [AuditEvent.model_validate(e) for e in data.get("events", [])]
+    logger.info("audit.client.fetch_pending_events", count=len(events))
+    return events
+
+
+async def mark_event_processed(
+    api_url: str,
+    api_key: str,
+    event_id: str,
+) -> None:
+    """Mark an audit event as processed after corrections have been submitted."""
+    url = f"{api_url}/api/agent/audit/events/{event_id}"
+    payload = {
+        "status": "processed",
+        "processed_at": datetime.now(tz=UTC).isoformat(),
+    }
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.patch(url, json=payload, headers=_headers(api_key))
+        resp.raise_for_status()
+    logger.info("audit.client.mark_processed", event_id=event_id)

--- a/src/audit/comparator.py
+++ b/src/audit/comparator.py
@@ -1,0 +1,161 @@
+"""Pure match comparison logic — no I/O, easily unit-tested."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from audit.models import AuditFinding
+
+
+def compare_matches(
+    scraped: list[dict[str, Any]],
+    mt_matches: list[dict[str, Any]],
+    team: str,
+) -> list[AuditFinding]:
+    """Compare scraped mlssoccer.com matches against MT records and return findings.
+
+    Match key strategy:
+    1. Primary: external_match_id (if both records have it)
+    2. Fallback: (home_team, away_team, match_date) tuple
+
+    Args:
+        scraped: Match dicts from MLSScraper (normalized team names).
+        mt_matches: Match dicts from MT /api/agent/matches.
+        team: MT canonical team name being audited (for logging context).
+
+    Returns:
+        List of AuditFinding describing discrepancies found.
+    """
+    findings: list[AuditFinding] = []
+
+    # Build indexed lookup maps for MT matches
+    mt_by_id: dict[str, int] = {}  # external_match_id -> list index
+    mt_by_key: dict[tuple[str, str, str], int] = {}  # (home, away, date) -> list index
+
+    for i, m in enumerate(mt_matches):
+        ext_id = m.get("external_match_id")
+        if ext_id:
+            mt_by_id[ext_id] = i
+        key = (m.get("home_team", ""), m.get("away_team", ""), m.get("match_date", ""))
+        mt_by_key[key] = i
+
+    # Track which MT indices were matched (to detect extras)
+    matched_mt_indices: set[int] = set()
+
+    for scraped_m in scraped:
+        ext_id = scraped_m.get("external_match_id")
+        key = (
+            scraped_m.get("home_team", ""),
+            scraped_m.get("away_team", ""),
+            scraped_m.get("match_date", ""),
+        )
+
+        # Locate corresponding MT match
+        mt_idx: int | None = None
+        if ext_id and ext_id in mt_by_id:
+            mt_idx = mt_by_id[ext_id]
+        elif key in mt_by_key:
+            mt_idx = mt_by_key[key]
+
+        if mt_idx is None:
+            findings.append(
+                AuditFinding(
+                    finding_type="missing_in_mt",
+                    home_team=scraped_m.get("home_team", ""),
+                    away_team=scraped_m.get("away_team", ""),
+                    match_date=scraped_m.get("match_date", ""),
+                    external_match_id=ext_id,
+                    scraped_match=scraped_m,
+                )
+            )
+            continue
+
+        matched_mt_indices.add(mt_idx)
+        mt_m = mt_matches[mt_idx]
+
+        # Score mismatch — only flag when scraped has a score
+        scraped_hs = scraped_m.get("home_score")
+        scraped_as = scraped_m.get("away_score")
+        mt_hs = mt_m.get("home_score")
+        mt_as = mt_m.get("away_score")
+        if scraped_hs is not None and (scraped_hs != mt_hs or scraped_as != mt_as):
+            findings.append(
+                AuditFinding(
+                    finding_type="score_mismatch",
+                    home_team=scraped_m.get("home_team", ""),
+                    away_team=scraped_m.get("away_team", ""),
+                    match_date=scraped_m.get("match_date", ""),
+                    external_match_id=ext_id,
+                    field="score",
+                    scraped_value=f"{scraped_hs}-{scraped_as}",
+                    mt_value=f"{mt_hs}-{mt_as}",
+                    scraped_match=scraped_m,
+                )
+            )
+
+        # Status mismatch
+        scraped_status = scraped_m.get("match_status")
+        mt_status = mt_m.get("match_status")
+        if scraped_status and scraped_status != mt_status:
+            findings.append(
+                AuditFinding(
+                    finding_type="status_mismatch",
+                    home_team=scraped_m.get("home_team", ""),
+                    away_team=scraped_m.get("away_team", ""),
+                    match_date=scraped_m.get("match_date", ""),
+                    external_match_id=ext_id,
+                    field="match_status",
+                    scraped_value=scraped_status,
+                    mt_value=mt_status,
+                    scraped_match=scraped_m,
+                )
+            )
+
+        # Time mismatch — only flag when scraped has a time
+        scraped_time = scraped_m.get("match_time")
+        mt_time = mt_m.get("match_time")
+        if scraped_time is not None and scraped_time != mt_time:
+            findings.append(
+                AuditFinding(
+                    finding_type="time_mismatch",
+                    home_team=scraped_m.get("home_team", ""),
+                    away_team=scraped_m.get("away_team", ""),
+                    match_date=scraped_m.get("match_date", ""),
+                    external_match_id=ext_id,
+                    field="match_time",
+                    scraped_value=scraped_time,
+                    mt_value=mt_time,
+                    scraped_match=scraped_m,
+                )
+            )
+
+    # Build a set of scraped keys for extra_in_mt detection
+    scraped_keys: set[tuple[str, str, str]] = {
+        (m.get("home_team", ""), m.get("away_team", ""), m.get("match_date", "")) for m in scraped
+    }
+    scraped_ids: set[str] = {m["external_match_id"] for m in scraped if m.get("external_match_id")}
+
+    # Extra in MT: MT matches with no corresponding scraped match
+    for i, mt_m in enumerate(mt_matches):
+        if i in matched_mt_indices:
+            continue
+        mt_ext_id = mt_m.get("external_match_id")
+        mt_key = (mt_m.get("home_team", ""), mt_m.get("away_team", ""), mt_m.get("match_date", ""))
+
+        # Double-check via both id and key to avoid false positives
+        if mt_ext_id and mt_ext_id in scraped_ids:
+            continue
+        if mt_key in scraped_keys:
+            continue
+
+        findings.append(
+            AuditFinding(
+                finding_type="extra_in_mt",
+                home_team=mt_m.get("home_team", ""),
+                away_team=mt_m.get("away_team", ""),
+                match_date=mt_m.get("match_date", ""),
+                external_match_id=mt_ext_id,
+            )
+        )
+
+    return findings

--- a/src/audit/models.py
+++ b/src/audit/models.py
@@ -1,0 +1,58 @@
+"""Pydantic v2 models for the audit module."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+
+class AuditFinding(BaseModel):
+    finding_type: Literal[
+        "missing_in_mt", "extra_in_mt", "score_mismatch", "status_mismatch", "time_mismatch"
+    ]
+    home_team: str
+    away_team: str
+    match_date: str
+    external_match_id: str | None = None
+    field: str | None = None  # "score" | "match_status" | "match_time"
+    scraped_value: str | None = None
+    mt_value: str | None = None
+    scraped_match: dict[str, Any] | None = None  # full dict for re-submission by processor
+
+
+class AuditEvent(BaseModel):
+    event_id: str
+    audit_run_id: str
+    team: str
+    age_group: str
+    league: str
+    division: str
+    season: str
+    findings: list[AuditFinding]
+    status: Literal["pending", "processed", "ignored"] = "pending"
+
+
+class NextTeamResponse(BaseModel):
+    team: str
+    age_group: str
+    league: str
+    division: str
+    season: str
+    last_audited_at: str | None = None
+
+
+class AuditRunResult(BaseModel):
+    team: str
+    age_group: str
+    scraped_count: int
+    mt_count: int
+    findings: list[AuditFinding]
+    dry_run: bool = False
+
+
+class ProcessResult(BaseModel):
+    events_processed: int
+    matches_resubmitted: int
+    extra_in_mt_flagged: int
+    errors: int

--- a/src/audit/processor.py
+++ b/src/audit/processor.py
@@ -1,0 +1,113 @@
+"""Audit event processor — resubmits corrections to RabbitMQ and marks events done."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from agent.tools import _current_season
+from audit.client import fetch_pending_events, mark_event_processed
+from audit.models import ProcessResult
+
+if TYPE_CHECKING:
+    from config.settings import AgentSettings
+
+logger = structlog.get_logger()
+
+# Finding types that trigger re-submission to RabbitMQ (scraped_match required)
+_RESUBMIT_TYPES = frozenset(
+    {"missing_in_mt", "score_mismatch", "status_mismatch", "time_mismatch"}
+)
+
+
+async def process_pending_events(
+    settings: AgentSettings,
+    queue_client: Any,
+    dry_run: bool,
+) -> ProcessResult:
+    """Fetch pending audit events and process each finding.
+
+    - missing_in_mt / score_mismatch / status_mismatch / time_mismatch:
+        submit scraped_match to RabbitMQ for MT upsert.
+    - extra_in_mt: log warning only (needs manual review).
+
+    Returns:
+        ProcessResult with counts of actions taken.
+    """
+    season = _current_season()
+    events = await fetch_pending_events(
+        api_url=settings.missing_table_api_url,
+        api_key=settings.missing_table_api_key or "",
+        season=season,
+    )
+
+    events_processed = 0
+    matches_resubmitted = 0
+    extra_in_mt_flagged = 0
+    errors = 0
+
+    for event in events:
+        try:
+            for finding in event.findings:
+                if finding.finding_type in _RESUBMIT_TYPES:
+                    if finding.scraped_match:
+                        if not dry_run:
+                            queue_client.submit_match(finding.scraped_match)
+                        matches_resubmitted += 1
+                        logger.info(
+                            "audit.processor.resubmit",
+                            finding_type=finding.finding_type,
+                            match=f"{finding.home_team} vs {finding.away_team}",
+                            match_date=finding.match_date,
+                            dry_run=dry_run,
+                        )
+                    else:
+                        logger.warning(
+                            "audit.processor.no_scraped_match",
+                            finding_type=finding.finding_type,
+                            match=f"{finding.home_team} vs {finding.away_team}",
+                        )
+                elif finding.finding_type == "extra_in_mt":
+                    extra_in_mt_flagged += 1
+                    logger.warning(
+                        "audit.processor.extra_in_mt",
+                        home_team=finding.home_team,
+                        away_team=finding.away_team,
+                        match_date=finding.match_date,
+                        external_match_id=finding.external_match_id,
+                        team=event.team,
+                        age_group=event.age_group,
+                    )
+
+            if not dry_run:
+                await mark_event_processed(
+                    api_url=settings.missing_table_api_url,
+                    api_key=settings.missing_table_api_key or "",
+                    event_id=event.event_id,
+                )
+            events_processed += 1
+
+        except Exception as exc:
+            errors += 1
+            logger.error(
+                "audit.processor.event_error",
+                event_id=event.event_id,
+                team=event.team,
+                error=str(exc),
+            )
+
+    logger.info(
+        "audit.processor.done",
+        events_processed=events_processed,
+        matches_resubmitted=matches_resubmitted,
+        extra_in_mt_flagged=extra_in_mt_flagged,
+        errors=errors,
+    )
+
+    return ProcessResult(
+        events_processed=events_processed,
+        matches_resubmitted=matches_resubmitted,
+        extra_in_mt_flagged=extra_in_mt_flagged,
+        errors=errors,
+    )

--- a/src/audit/report.py
+++ b/src/audit/report.py
@@ -1,0 +1,75 @@
+"""Telegram MarkdownV2 report builders for audit commands."""
+
+from __future__ import annotations
+
+from telegram_notify import escape
+
+from audit.models import AuditRunResult, ProcessResult
+
+
+def build_audit_report(result: AuditRunResult, env: str) -> str:
+    """Build a MarkdownV2 audit report for Telegram.
+
+    Only called when findings exist — clean runs are silent.
+    """
+    lines: list[str] = []
+    lines.append("*Audit Report*")
+
+    team_label = escape(f"{result.team} {result.age_group}")
+    env_label = escape(env)
+    dry_suffix = escape(" · DRY RUN") if result.dry_run else ""
+    lines.append(f"_{team_label} · {env_label}{dry_suffix}_")
+    lines.append("")
+
+    lines.append(
+        f"*Scraped:* {escape(str(result.scraped_count))} · "
+        f"*MT:* {escape(str(result.mt_count))} · "
+        f"*Findings:* {escape(str(len(result.findings)))}"
+    )
+    lines.append("")
+
+    # Group findings by type
+    by_type: dict[str, list] = {}
+    for f in result.findings:
+        by_type.setdefault(f.finding_type, []).append(f)
+
+    for ftype, flist in sorted(by_type.items()):
+        type_label = escape(ftype.replace("_", " ").title())
+        count_label = escape(str(len(flist)))
+        lines.append(f"*{type_label} \\({count_label}\\):*")
+        for f in flist:
+            home = escape(f.home_team)
+            away = escape(f.away_team)
+            md = escape(f.match_date)
+            detail = ""
+            if f.field:
+                scraped_val = escape(f.scraped_value or "?")
+                mt_val = escape(f.mt_value or "?")
+                field_label = escape(f.field)
+                detail = f" — {field_label}: {scraped_val} vs {mt_val}"
+            lines.append(f"  • {md} {home} vs {away}{detail}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def build_processor_report(result: ProcessResult, env: str) -> str:
+    """Build a MarkdownV2 processor report for Telegram.
+
+    Only called when matches were resubmitted or extra_in_mt were flagged.
+    """
+    lines: list[str] = []
+    lines.append("*Audit Processor Report*")
+    lines.append(f"_{escape(env)}_")
+    lines.append("")
+
+    lines.append(
+        f"*Events processed:* {escape(str(result.events_processed))} · "
+        f"*Resubmitted:* {escape(str(result.matches_resubmitted))} · "
+        f"*Flagged extra:* {escape(str(result.extra_in_mt_flagged))}"
+    )
+
+    if result.errors:
+        lines.append(f"*Errors:* {escape(str(result.errors))}")
+
+    return "\n".join(lines)

--- a/src/audit/runner.py
+++ b/src/audit/runner.py
@@ -1,0 +1,158 @@
+"""One-team audit orchestrator — fetches next team, scrapes, compares, submits findings."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+import structlog
+
+from agent.tools import TEAM_NAME_MAP, _current_season, _normalize_team_name
+from audit.client import fetch_mt_matches, fetch_next_team, submit_audit_event
+from audit.comparator import compare_matches
+from audit.models import AuditEvent, AuditRunResult
+from config.settings import AgentSettings
+
+logger = structlog.get_logger()
+
+# Reverse map: MT canonical name → MLS Next display name (used for scraper club= filter)
+MT_NAME_TO_MLS_NAME: dict[str, str] = {v: k for k, v in TEAM_NAME_MAP.items()}
+
+
+async def run_one_team_audit(
+    settings: AgentSettings,
+    dry_run: bool,
+    season_start: date,
+    season_end: date,
+) -> AuditRunResult | None:
+    """Audit one team: scrape mlssoccer.com, compare against MT, submit findings.
+
+    Returns:
+        AuditRunResult if a team was audited, None if all teams are up-to-date.
+    """
+    from src.scraper.config import ScrapingConfig
+    from src.scraper.mls_scraper import MLSScraper
+
+    season = _current_season()
+    audit_run_id = uuid.uuid4().hex[:12]
+    event_id = uuid.uuid4().hex[:12]
+
+    # Step 1: Fetch next team to audit (least recently audited)
+    next_team = await fetch_next_team(
+        api_url=settings.missing_table_api_url,
+        api_key=settings.missing_table_api_key or "",
+        season=season,
+        division="Northeast",
+        league="Homegrown",
+    )
+    if next_team is None:
+        logger.info("audit.runner.all_current")
+        return None
+
+    team = next_team.team
+    age_group = next_team.age_group
+    league = next_team.league
+    division = next_team.division
+    logger.info(
+        "audit.runner.team_selected",
+        team=team,
+        age_group=age_group,
+        audit_run_id=audit_run_id,
+    )
+
+    # Step 2: Build ScrapingConfig — map MT canonical name back to MLS Next display name
+    mls_club_name = MT_NAME_TO_MLS_NAME.get(team, team)
+    config = ScrapingConfig(
+        age_group=age_group,
+        league=league,
+        division=division,
+        conference="",
+        club=mls_club_name,
+        start_date=season_start,
+        end_date=season_end,
+        look_back_days=(season_end - season_start).days,
+        missing_table_api_url=settings.missing_table_api_url,
+        missing_table_api_key=settings.missing_table_api_key or "unused",
+    )
+
+    # Step 3: Scrape matches via Playwright
+    scraper = MLSScraper(config, headless=settings.headless)
+    raw_matches = await scraper.scrape_matches()
+    logger.info("audit.runner.scraped_raw", count=len(raw_matches))
+
+    # Step 4: Normalize into match dicts (same logic as tools.py / scrape command)
+    mt_division = config.conference if config.conference else config.division
+    scraped = [
+        {
+            "home_team": _normalize_team_name(m.home_team, league=league),
+            "away_team": _normalize_team_name(m.away_team, league=league),
+            "match_date": m.match_datetime.date().isoformat(),
+            "match_time": (
+                m.match_datetime.strftime("%H:%M")
+                if m.match_datetime.hour or m.match_datetime.minute
+                else None
+            ),
+            "season": season,
+            "age_group": age_group,
+            "match_type": "League",
+            "division": mt_division,
+            "league": league,
+            "home_score": m.home_score if isinstance(m.home_score, int) else None,
+            "away_score": m.away_score if isinstance(m.away_score, int) else None,
+            "match_status": m.match_status,
+            "external_match_id": m.match_id,
+            "location": m.location,
+            "source": "match-scraper-agent",
+        }
+        for m in raw_matches
+    ]
+
+    # Step 5: Fetch MT matches for this team
+    mt_matches = await fetch_mt_matches(
+        api_url=settings.missing_table_api_url,
+        api_key=settings.missing_table_api_key or "",
+        age_group=age_group,
+        league=league,
+        division=division,
+        team=team,
+        season=season,
+    )
+    logger.info("audit.runner.mt_matches", count=len(mt_matches))
+
+    # Step 6: Compare scraped vs MT
+    findings = compare_matches(scraped, mt_matches, team)
+    logger.info("audit.runner.findings", count=len(findings), team=team, age_group=age_group)
+
+    # Step 7: Submit audit event (even if clean — records last_audited_at)
+    event = AuditEvent(
+        event_id=event_id,
+        audit_run_id=audit_run_id,
+        team=team,
+        age_group=age_group,
+        league=league,
+        division=division,
+        season=season,
+        findings=findings,
+    )
+
+    if dry_run:
+        logger.info(
+            "audit.runner.dry_run_skip_submit",
+            event_id=event_id,
+            findings=len(findings),
+        )
+    else:
+        await submit_audit_event(
+            api_url=settings.missing_table_api_url,
+            api_key=settings.missing_table_api_key or "",
+            event=event,
+        )
+
+    return AuditRunResult(
+        team=team,
+        age_group=age_group,
+        scraped_count=len(scraped),
+        mt_count=len(mt_matches),
+        findings=findings,
+        dry_run=dry_run,
+    )

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -672,3 +672,168 @@ def scrape(
                     error=str(exc),
                 )
         typer.echo(f"\nSubmitted {submitted} matches to queue ({errors} errors).")
+
+
+def _send_telegram_audit_report(
+    settings: AgentSettings,
+    result: Any,
+    env: str,
+) -> None:
+    """Send audit findings report to Telegram. Silently skips if not configured."""
+    if not settings.telegram_bot_token or not settings.telegram_chat_id:
+        logger.debug("telegram.skipped", reason="not configured")
+        return
+
+    from telegram_notify import TelegramClient
+
+    from audit.report import build_audit_report
+
+    report = build_audit_report(result=result, env=env)
+    try:
+        client = TelegramClient(
+            bot_token=settings.telegram_bot_token,
+            chat_id=settings.telegram_chat_id,
+        )
+        client.send(report)
+        logger.info("telegram.sent", chat_id=settings.telegram_chat_id)
+    except Exception as exc:
+        logger.warning("telegram.failed", error=str(exc))
+
+
+def _send_telegram_processor_report(
+    settings: AgentSettings,
+    result: Any,
+    env: str,
+) -> None:
+    """Send processor summary report to Telegram. Silently skips if not configured."""
+    if not settings.telegram_bot_token or not settings.telegram_chat_id:
+        logger.debug("telegram.skipped", reason="not configured")
+        return
+
+    from telegram_notify import TelegramClient
+
+    from audit.report import build_processor_report
+
+    report = build_processor_report(result=result, env=env)
+    try:
+        client = TelegramClient(
+            bot_token=settings.telegram_bot_token,
+            chat_id=settings.telegram_chat_id,
+        )
+        client.send(report)
+        logger.info("telegram.sent", chat_id=settings.telegram_chat_id)
+    except Exception as exc:
+        logger.warning("telegram.failed", error=str(exc))
+
+
+@app.command()
+def audit(
+    env: Annotated[str, typer.Option("--env", help="Environment name (local, prod)")] = "local",
+    dry_run: Annotated[bool, typer.Option("--dry-run", help="Skip mutating operations")] = False,
+    json_logs: Annotated[bool, typer.Option("--json-logs", help="Output JSON log lines")] = False,
+) -> None:
+    """Audit one team against mlssoccer.com source of truth."""
+    import asyncio
+    from datetime import date
+
+    from audit.runner import run_one_team_audit
+    from config.settings import AgentSettings, env_file_path
+    from utils.logger import configure_logging
+
+    settings = AgentSettings(_env_file=env_file_path(env))
+    configure_logging(json_output=json_logs or settings.json_logs, log_level=settings.log_level)
+
+    run_id = uuid.uuid4().hex[:12]
+    structlog.contextvars.bind_contextvars(run_id=run_id, env=env)
+
+    try:
+        season_start = date.fromisoformat(settings.audit_season_start)
+    except ValueError:
+        typer.echo(f"Invalid AGENT_AUDIT_SEASON_START: {settings.audit_season_start}", err=True)
+        raise typer.Exit(code=1) from None
+
+    from agent.tools import SEASON_END
+
+    try:
+        result = asyncio.run(
+            run_one_team_audit(
+                settings=settings,
+                dry_run=dry_run,
+                season_start=season_start,
+                season_end=SEASON_END,
+            )
+        )
+    except Exception as exc:
+        logger.error("audit.failed", error=str(exc), exc_info=exc)
+        raise typer.Exit(code=1) from None
+
+    if result is None:
+        logger.info("audit.all_teams_current")
+        typer.echo("All teams are up-to-date. Nothing to audit.")
+    else:
+        logger.info(
+            "audit.completed",
+            team=result.team,
+            age_group=result.age_group,
+            scraped=result.scraped_count,
+            mt=result.mt_count,
+            findings=len(result.findings),
+        )
+        typer.echo(
+            f"Audited {result.team} {result.age_group}: "
+            f"{result.scraped_count} scraped, {result.mt_count} in MT, "
+            f"{len(result.findings)} findings"
+        )
+        if result.findings:
+            _send_telegram_audit_report(settings=settings, result=result, env=env)
+
+    structlog.contextvars.unbind_contextvars("run_id", "env")
+
+
+@app.command(name="audit-process")
+def audit_process(
+    env: Annotated[str, typer.Option("--env", help="Environment name (local, prod)")] = "local",
+    dry_run: Annotated[bool, typer.Option("--dry-run", help="Skip mutating operations")] = False,
+    json_logs: Annotated[bool, typer.Option("--json-logs", help="Output JSON log lines")] = False,
+) -> None:
+    """Process pending audit findings — resubmit corrections to RabbitMQ."""
+    import asyncio
+
+    from src.celery.queue_client import MatchQueueClient
+
+    from audit.processor import process_pending_events
+    from config.settings import AgentSettings, env_file_path
+    from utils.logger import configure_logging
+
+    settings = AgentSettings(_env_file=env_file_path(env))
+    configure_logging(json_output=json_logs or settings.json_logs, log_level=settings.log_level)
+
+    run_id = uuid.uuid4().hex[:12]
+    structlog.contextvars.bind_contextvars(run_id=run_id, env=env)
+
+    queue_client = MatchQueueClient(**_queue_client_kwargs(settings))
+
+    try:
+        result = asyncio.run(
+            process_pending_events(
+                settings=settings,
+                queue_client=queue_client,
+                dry_run=dry_run,
+            )
+        )
+    except Exception as exc:
+        logger.error("audit_process.failed", error=str(exc), exc_info=exc)
+        raise typer.Exit(code=1) from None
+
+    logger.info(
+        "audit_process.completed",
+        events_processed=result.events_processed,
+        matches_resubmitted=result.matches_resubmitted,
+        extra_in_mt_flagged=result.extra_in_mt_flagged,
+        errors=result.errors,
+    )
+
+    if result.matches_resubmitted or result.extra_in_mt_flagged:
+        _send_telegram_processor_report(settings=settings, result=result, env=env)
+
+    structlog.contextvars.unbind_contextvars("run_id", "env")

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -59,6 +59,9 @@ class AgentSettings(BaseSettings):
     telegram_bot_token: str = ""
     telegram_chat_id: str = ""
 
+    # Audit settings
+    audit_season_start: str = "2026-02-01"  # Spring segment start date
+
     # Database (missing-table Supabase — used by trigger.sh post-run verification)
     db_host: str = "127.0.0.1"
     db_port: int = 54332

--- a/tests/test_audit_comparator.py
+++ b/tests/test_audit_comparator.py
@@ -1,0 +1,214 @@
+"""Unit tests for audit.comparator — pure comparison logic, no I/O."""
+
+from __future__ import annotations
+
+import pytest
+
+from audit.comparator import compare_matches
+
+
+def _match(
+    home: str,
+    away: str,
+    date: str,
+    *,
+    ext_id: str | None = None,
+    status: str = "scheduled",
+    home_score: int | None = None,
+    away_score: int | None = None,
+    match_time: str | None = None,
+) -> dict:
+    return {
+        "home_team": home,
+        "away_team": away,
+        "match_date": date,
+        "external_match_id": ext_id,
+        "match_status": status,
+        "home_score": home_score,
+        "away_score": away_score,
+        "match_time": match_time,
+    }
+
+
+class TestClean:
+    def test_no_findings_when_identical(self):
+        m = _match("IFA", "Arsenal", "2026-03-15", ext_id="abc1", status="scheduled")
+        findings = compare_matches([m], [m], "IFA")
+        assert findings == []
+
+    def test_no_findings_empty_both(self):
+        findings = compare_matches([], [], "IFA")
+        assert findings == []
+
+    def test_no_findings_empty_scraped(self):
+        m = _match("IFA", "Arsenal", "2026-03-15", ext_id="abc1")
+        # MT has a match but nothing scraped — this is extra_in_mt, not missing
+        findings = compare_matches([], [m], "IFA")
+        assert len(findings) == 1
+        assert findings[0].finding_type == "extra_in_mt"
+
+    def test_no_findings_with_score(self):
+        m = _match("IFA", "Arsenal", "2026-03-15", ext_id="abc1", status="completed",
+                   home_score=2, away_score=1)
+        findings = compare_matches([m], [m], "IFA")
+        assert findings == []
+
+
+class TestMissingInMT:
+    def test_scraped_not_in_mt(self):
+        scraped = _match("IFA", "Arsenal", "2026-03-15", ext_id="abc1")
+        findings = compare_matches([scraped], [], "IFA")
+        assert len(findings) == 1
+        assert findings[0].finding_type == "missing_in_mt"
+        assert findings[0].home_team == "IFA"
+        assert findings[0].away_team == "Arsenal"
+        assert findings[0].match_date == "2026-03-15"
+        assert findings[0].scraped_match is not None
+
+    def test_scraped_not_in_mt_no_ext_id(self):
+        scraped = _match("IFA", "Arsenal", "2026-03-15")  # no ext_id
+        findings = compare_matches([scraped], [], "IFA")
+        assert len(findings) == 1
+        assert findings[0].finding_type == "missing_in_mt"
+
+    def test_multiple_missing(self):
+        matches = [
+            _match("IFA", "Arsenal", "2026-03-15", ext_id="a1"),
+            _match("IFA", "Chelsea", "2026-03-22", ext_id="a2"),
+        ]
+        findings = compare_matches(matches, [], "IFA")
+        assert len(findings) == 2
+        assert all(f.finding_type == "missing_in_mt" for f in findings)
+
+
+class TestExtraInMT:
+    def test_mt_match_not_scraped(self):
+        mt = _match("IFA", "Arsenal", "2026-03-15", ext_id="abc1")
+        findings = compare_matches([], [mt], "IFA")
+        assert len(findings) == 1
+        assert findings[0].finding_type == "extra_in_mt"
+        assert findings[0].home_team == "IFA"
+        assert findings[0].scraped_match is None  # no scraped_match for extra_in_mt
+
+    def test_extra_has_no_scraped_match(self):
+        mt = _match("IFA", "Arsenal", "2026-03-15", ext_id="abc1")
+        findings = compare_matches([], [mt], "IFA")
+        assert findings[0].scraped_match is None
+
+
+class TestScoreMismatch:
+    def test_score_differs(self):
+        scraped = _match("IFA", "Arsenal", "2026-03-15", ext_id="abc1",
+                         status="completed", home_score=2, away_score=1)
+        mt = _match("IFA", "Arsenal", "2026-03-15", ext_id="abc1",
+                    status="completed", home_score=1, away_score=1)
+        findings = compare_matches([scraped], [mt], "IFA")
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.finding_type == "score_mismatch"
+        assert f.field == "score"
+        assert f.scraped_value == "2-1"
+        assert f.mt_value == "1-1"
+        assert f.scraped_match is not None
+
+    def test_no_score_mismatch_when_scraped_score_is_none(self):
+        scraped = _match("IFA", "Arsenal", "2026-03-15", ext_id="abc1",
+                         status="scheduled", home_score=None, away_score=None)
+        mt = _match("IFA", "Arsenal", "2026-03-15", ext_id="abc1",
+                    status="scheduled", home_score=2, away_score=1)
+        findings = compare_matches([scraped], [mt], "IFA")
+        assert not any(f.finding_type == "score_mismatch" for f in findings)
+
+
+class TestStatusMismatch:
+    def test_status_differs(self):
+        scraped = _match("IFA", "Arsenal", "2026-03-15", ext_id="abc1", status="completed")
+        mt = _match("IFA", "Arsenal", "2026-03-15", ext_id="abc1", status="scheduled")
+        findings = compare_matches([scraped], [mt], "IFA")
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.finding_type == "status_mismatch"
+        assert f.field == "match_status"
+        assert f.scraped_value == "completed"
+        assert f.mt_value == "scheduled"
+        assert f.scraped_match is not None
+
+    def test_no_mismatch_when_status_matches(self):
+        m = _match("IFA", "Arsenal", "2026-03-15", ext_id="abc1", status="completed")
+        findings = compare_matches([m], [m], "IFA")
+        assert findings == []
+
+
+class TestTimeMismatch:
+    def test_time_differs(self):
+        scraped = _match("IFA", "Arsenal", "2026-03-15", ext_id="abc1",
+                         status="scheduled", match_time="10:00")
+        mt = _match("IFA", "Arsenal", "2026-03-15", ext_id="abc1",
+                    status="scheduled", match_time="11:00")
+        findings = compare_matches([scraped], [mt], "IFA")
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.finding_type == "time_mismatch"
+        assert f.field == "match_time"
+        assert f.scraped_value == "10:00"
+        assert f.mt_value == "11:00"
+        assert f.scraped_match is not None
+
+    def test_no_time_mismatch_when_scraped_time_is_none(self):
+        scraped = _match("IFA", "Arsenal", "2026-03-15", ext_id="abc1",
+                         status="scheduled", match_time=None)
+        mt = _match("IFA", "Arsenal", "2026-03-15", ext_id="abc1",
+                    status="scheduled", match_time="10:00")
+        findings = compare_matches([scraped], [mt], "IFA")
+        assert not any(f.finding_type == "time_mismatch" for f in findings)
+
+
+class TestMatchKeyStrategy:
+    def test_match_by_ext_id_takes_priority(self):
+        # Different home/away but same ext_id — should match (no missing/extra)
+        scraped = _match("IFA", "Arsenal", "2026-03-15", ext_id="abc1")
+        mt = _match("IFA FC", "Arsenal FC", "2026-03-15", ext_id="abc1")
+        findings = compare_matches([scraped], [mt], "IFA")
+        # Status both "scheduled" + same → only possible status finding, not missing/extra
+        assert not any(f.finding_type in ("missing_in_mt", "extra_in_mt") for f in findings)
+
+    def test_fallback_to_key_when_no_ext_id(self):
+        scraped = _match("IFA", "Arsenal", "2026-03-15")  # no ext_id
+        mt = _match("IFA", "Arsenal", "2026-03-15")  # no ext_id, same key
+        findings = compare_matches([scraped], [mt], "IFA")
+        assert findings == []
+
+    def test_different_ext_ids_not_matched_by_key(self):
+        # Same key but different ext_ids — ext_id lookup should take priority
+        # MT has ext_id "mt1", scraped has ext_id "scraped1"
+        # They should NOT match by fallback key since ext_id lookup is tried first
+        scraped = _match("IFA", "Arsenal", "2026-03-15", ext_id="scraped1")
+        mt = _match("IFA", "Arsenal", "2026-03-15", ext_id="mt1")
+        # Scraped won't find "scraped1" in mt_by_id → falls back to key match
+        findings = compare_matches([scraped], [mt], "IFA")
+        # Matched via fallback key — no missing/extra
+        assert not any(f.finding_type in ("missing_in_mt", "extra_in_mt") for f in findings)
+
+
+class TestMultipleFindings:
+    def test_score_and_status_mismatch_on_same_match(self):
+        scraped = _match("IFA", "Arsenal", "2026-03-15", ext_id="abc1",
+                         status="completed", home_score=2, away_score=1)
+        mt = _match("IFA", "Arsenal", "2026-03-15", ext_id="abc1",
+                    status="scheduled", home_score=0, away_score=0)
+        findings = compare_matches([scraped], [mt], "IFA")
+        types = {f.finding_type for f in findings}
+        assert "score_mismatch" in types
+        assert "status_mismatch" in types
+
+    def test_mixed_clean_and_dirty(self):
+        clean = _match("IFA", "Arsenal", "2026-03-15", ext_id="abc1", status="scheduled")
+        dirty_scraped = _match("IFA", "Chelsea", "2026-03-22", ext_id="abc2",
+                                status="completed", home_score=3, away_score=0)
+        dirty_mt = _match("IFA", "Chelsea", "2026-03-22", ext_id="abc2",
+                           status="scheduled", home_score=None, away_score=None)
+        findings = compare_matches([clean, dirty_scraped], [clean, dirty_mt], "IFA")
+        assert len(findings) == 2  # score_mismatch + status_mismatch
+        assert all(
+            f.home_team == "IFA" and f.away_team == "Chelsea" for f in findings
+        )


### PR DESCRIPTION
## Summary

Full audit system for Northeast HG division (U13–U16): scrapes mlssoccer.com per-team, compares against MT, stores findings, and resubmits corrections via RabbitMQ.

**Companion PR:** silverbeer/missing-table#243 (audit tables + API endpoints — merge that first)

## New files

| File | Purpose |
|------|---------|
| `src/audit/models.py` | Pydantic v2 models |
| `src/audit/client.py` | Async httpx wrappers for MT audit endpoints |
| `src/audit/comparator.py` | Pure comparison logic (no I/O) |
| `src/audit/runner.py` | One-team audit orchestrator |
| `src/audit/processor.py` | Resubmits pending findings to RabbitMQ |
| `src/audit/report.py` | Telegram MarkdownV2 report builders |
| `k3s/audit/cronjob-audit.yaml` | CronJob: 6x/day at `0 1,5,9,13,17,21` |
| `k3s/audit/cronjob-audit-process.yaml` | CronJob: 6x/day at `30 1,5,9,13,17,21` |
| `tests/test_audit_comparator.py` | 20 unit tests (all passing) |

## Modified files

- `src/cli/main.py` — `audit` and `audit-process` commands + Telegram helpers
- `src/config/settings.py` — `audit_season_start` setting
- `k3s/match-scraper-agent/configmap.yaml` — `AGENT_AUDIT_SEASON_START`
- `pyproject.toml` — `src/audit` added to wheel packages

## Test plan

- [ ] `cd tests && uv run pytest test_audit_comparator.py -v` — 20 tests pass
- [ ] `uv run match-scraper-agent audit --env local --dry-run` (after MT PR merged + migration applied)
- [ ] `uv run match-scraper-agent audit-process --env local --dry-run`
- [ ] K3s deploy: `kubectl apply -f k3s/audit/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)