### PR TITLE
fix: K3s infra fixes for audit CronJob deployment

### DIFF
--- a/k3s/deploy.sh
+++ b/k3s/deploy.sh
@@ -9,6 +9,7 @@
 # Required vars in envs/.env.prod:
 #   AGENT_ANTHROPIC_API_KEY       — API key (or "agent-via-proxy" when using proxy)
 #   AGENT_MISSING_TABLE_API_KEY   — missing-table API key
+#   AGENT_TELEGRAM_BOT_TOKEN     — Telegram bot token for notifications
 
 set -euo pipefail
 
@@ -55,6 +56,7 @@ type: Opaque
 stringData:
   AGENT_ANTHROPIC_API_KEY: "$AGENT_ANTHROPIC_API_KEY"
   AGENT_MISSING_TABLE_API_KEY: "$AGENT_MISSING_TABLE_API_KEY"
+  AGENT_TELEGRAM_BOT_TOKEN: "$AGENT_TELEGRAM_BOT_TOKEN"
 EOF
 
 echo "Generated $SECRET_FILE"

--- a/k3s/match-scraper-agent/configmap.yaml
+++ b/k3s/match-scraper-agent/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   AGENT_PROXY_BASE_URL: "http://iron-claw-proxy.iron-claw.svc.cluster.local:8100"
   AGENT_MODEL_NAME: "claude-haiku-4-5-20251001"
-  AGENT_RABBITMQ_URL: "amqp://admin:admin123@messaging-rabbitmq.match-scraper.svc.cluster.local:5672//"
+  AGENT_RABBITMQ_URL: "amqp://admin:admin123@rabbitmq.match-scraper.svc.cluster.local:5672//"
   AGENT_QUEUE_NAME: "matches.prod"
   AGENT_LEAGUE: "Homegrown"
   AGENT_AGE_GROUP: "U14"
@@ -18,3 +18,4 @@ data:
   AGENT_DRY_RUN: "false"
   AGENT_JSON_LOGS: "true"
   AGENT_AUDIT_SEASON_START: "2026-02-01"
+  AGENT_TELEGRAM_CHAT_ID: "-5109858197"

--- a/k3s/rabbitmq/configmap.yaml
+++ b/k3s/rabbitmq/configmap.yaml
@@ -6,6 +6,11 @@ metadata:
 data:
   definitions.json: |
     {
+      "vhosts": [
+        {
+          "name": "/"
+        }
+      ],
       "exchanges": [
         {
           "name": "matches-fanout",

--- a/k3s/rabbitmq/deployment.yaml
+++ b/k3s/rabbitmq/deployment.yaml
@@ -25,9 +25,9 @@ spec:
               name: management
           env:
             - name: RABBITMQ_DEFAULT_USER
-              value: "guest"
+              value: "admin"
             - name: RABBITMQ_DEFAULT_PASS
-              value: "guest"
+              value: "admin123"
             - name: RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS
               value: "-rabbitmq_management load_definitions \"/etc/rabbitmq/definitions.json\""
           readinessProbe:


### PR DESCRIPTION
## Summary
- Fix RabbitMQ service hostname in configmap (`messaging-rabbitmq` → `rabbitmq`) — was causing DNS resolution failures in audit-process
- Add vhost `"/"` to RabbitMQ definitions.json — prevents crash on fresh pod startup
- Set RabbitMQ default credentials to `admin:admin123` to match agent AMQP URL
- Add Telegram notifications for audit jobs (bot token in secret, chat ID in configmap)
- Update `deploy.sh` to include `AGENT_TELEGRAM_BOT_TOKEN` in generated secret

## Context
These fixes were discovered during smoke-testing the new audit CronJobs. All changes have been applied to the live K3s cluster and verified:
- `match-scraper-audit` — smoke-tested, Telegram notification confirmed
- `match-scraper-audit-process` — smoke-tested, resubmitted 12 matches, Telegram notification confirmed
- RabbitMQ — stable after vhost + credential fixes

## Test plan
- [x] Audit smoke test passes end-to-end (scrape → compare → submit event → Telegram)
- [x] Audit-process smoke test passes (fetch events → resubmit → mark processed → Telegram)
- [x] RabbitMQ pod starts cleanly with definitions import
- [x] Telegram messages appear in Match Scraper Agent channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)