### PR TITLE
feat: Auto-cancel extra_in_mt matches older than 7 days

### DIFF
--- a/src/audit/client.py
+++ b/src/audit/client.py
@@ -109,6 +109,48 @@ async def fetch_pending_events(
     return events
 
 
+async def cancel_match(
+    api_url: str,
+    api_key: str,
+    home_team: str,
+    away_team: str,
+    match_date: str,
+    age_group: str,
+    league: str,
+    division: str,
+    season: str,
+) -> bool:
+    """Mark a match as cancelled in MT. Returns True if found and cancelled."""
+    url = f"{api_url}/api/agent/matches/cancel"
+    payload = {
+        "home_team": home_team,
+        "away_team": away_team,
+        "match_date": match_date,
+        "age_group": age_group,
+        "league": league,
+        "division": division,
+        "season": season,
+    }
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.patch(url, json=payload, headers=_headers(api_key))
+        if resp.status_code == 404:
+            logger.warning(
+                "audit.client.cancel_match.not_found",
+                home_team=home_team,
+                away_team=away_team,
+                match_date=match_date,
+            )
+            return False
+        resp.raise_for_status()
+    logger.info(
+        "audit.client.cancel_match",
+        home_team=home_team,
+        away_team=away_team,
+        match_date=match_date,
+    )
+    return True
+
+
 async def mark_event_processed(
     api_url: str,
     api_key: str,

--- a/src/audit/models.py
+++ b/src/audit/models.py
@@ -54,5 +54,6 @@ class AuditRunResult(BaseModel):
 class ProcessResult(BaseModel):
     events_processed: int
     matches_resubmitted: int
-    extra_in_mt_flagged: int
+    extra_in_mt_cancelled: int
+    extra_in_mt_skipped: int  # within 7-day window, left alone
     errors: int

--- a/src/audit/processor.py
+++ b/src/audit/processor.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+from datetime import date, timedelta
 from typing import TYPE_CHECKING, Any
 
 import structlog
 
 from agent.tools import _current_season
-from audit.client import fetch_pending_events, mark_event_processed
+from audit.client import cancel_match, fetch_pending_events, mark_event_processed
 from audit.models import ProcessResult
 
 if TYPE_CHECKING:
@@ -20,6 +21,10 @@ _RESUBMIT_TYPES = frozenset(
     {"missing_in_mt", "score_mismatch", "status_mismatch", "time_mismatch"}
 )
 
+# extra_in_mt findings older than this are cancelled in MT; newer ones are left alone
+# (matches get rescheduled and mlssoccer.com can lag — give it a full week)
+_CANCEL_THRESHOLD_DAYS = 7
+
 
 async def process_pending_events(
     settings: AgentSettings,
@@ -30,7 +35,8 @@ async def process_pending_events(
 
     - missing_in_mt / score_mismatch / status_mismatch / time_mismatch:
         submit scraped_match to RabbitMQ for MT upsert.
-    - extra_in_mt: log warning only (needs manual review).
+    - extra_in_mt (> 7 days old, no score): cancel in MT automatically.
+    - extra_in_mt (< 7 days old): skip — may be a reschedule in progress.
 
     Returns:
         ProcessResult with counts of actions taken.
@@ -44,8 +50,10 @@ async def process_pending_events(
 
     events_processed = 0
     matches_resubmitted = 0
-    extra_in_mt_flagged = 0
+    extra_in_mt_cancelled = 0
+    extra_in_mt_skipped = 0
     errors = 0
+    cancel_threshold = date.today() - timedelta(days=_CANCEL_THRESHOLD_DAYS)
 
     for event in events:
         try:
@@ -69,16 +77,46 @@ async def process_pending_events(
                             match=f"{finding.home_team} vs {finding.away_team}",
                         )
                 elif finding.finding_type == "extra_in_mt":
-                    extra_in_mt_flagged += 1
-                    logger.warning(
-                        "audit.processor.extra_in_mt",
-                        home_team=finding.home_team,
-                        away_team=finding.away_team,
-                        match_date=finding.match_date,
-                        external_match_id=finding.external_match_id,
-                        team=event.team,
-                        age_group=event.age_group,
-                    )
+                    try:
+                        match_date = date.fromisoformat(finding.match_date)
+                    except ValueError:
+                        logger.warning(
+                            "audit.processor.extra_in_mt.bad_date",
+                            match_date=finding.match_date,
+                        )
+                        extra_in_mt_skipped += 1
+                        continue
+
+                    if match_date < cancel_threshold:
+                        if not dry_run:
+                            await cancel_match(
+                                api_url=settings.missing_table_api_url,
+                                api_key=settings.missing_table_api_key or "",
+                                home_team=finding.home_team,
+                                away_team=finding.away_team,
+                                match_date=finding.match_date,
+                                age_group=event.age_group,
+                                league=event.league,
+                                division=event.division,
+                                season=event.season,
+                            )
+                        extra_in_mt_cancelled += 1
+                        logger.info(
+                            "audit.processor.extra_in_mt.cancelled",
+                            home_team=finding.home_team,
+                            away_team=finding.away_team,
+                            match_date=finding.match_date,
+                            dry_run=dry_run,
+                        )
+                    else:
+                        extra_in_mt_skipped += 1
+                        logger.info(
+                            "audit.processor.extra_in_mt.skipped",
+                            home_team=finding.home_team,
+                            away_team=finding.away_team,
+                            match_date=finding.match_date,
+                            reason="within_7_day_window",
+                        )
 
             if not dry_run:
                 await mark_event_processed(
@@ -101,13 +139,15 @@ async def process_pending_events(
         "audit.processor.done",
         events_processed=events_processed,
         matches_resubmitted=matches_resubmitted,
-        extra_in_mt_flagged=extra_in_mt_flagged,
+        extra_in_mt_cancelled=extra_in_mt_cancelled,
+        extra_in_mt_skipped=extra_in_mt_skipped,
         errors=errors,
     )
 
     return ProcessResult(
         events_processed=events_processed,
         matches_resubmitted=matches_resubmitted,
-        extra_in_mt_flagged=extra_in_mt_flagged,
+        extra_in_mt_cancelled=extra_in_mt_cancelled,
+        extra_in_mt_skipped=extra_in_mt_skipped,
         errors=errors,
     )

--- a/src/audit/report.py
+++ b/src/audit/report.py
@@ -56,18 +56,20 @@ def build_audit_report(result: AuditRunResult, env: str) -> str:
 def build_processor_report(result: ProcessResult, env: str) -> str:
     """Build a MarkdownV2 processor report for Telegram.
 
-    Only called when matches were resubmitted or extra_in_mt were flagged.
+    Only called when matches were resubmitted or extra_in_mt were acted on.
     """
     lines: list[str] = []
     lines.append("*Audit Processor Report*")
     lines.append(f"_{escape(env)}_")
     lines.append("")
 
-    lines.append(
-        f"*Events processed:* {escape(str(result.events_processed))} · "
-        f"*Resubmitted:* {escape(str(result.matches_resubmitted))} · "
-        f"*Flagged extra:* {escape(str(result.extra_in_mt_flagged))}"
-    )
+    parts = [
+        f"*Corrected:* {escape(str(result.matches_resubmitted))}",
+        f"*Cancelled:* {escape(str(result.extra_in_mt_cancelled))}",
+    ]
+    if result.extra_in_mt_skipped:
+        parts.append(f"*Pending \\(< 7d\\):* {escape(str(result.extra_in_mt_skipped))}")
+    lines.append(" · ".join(parts))
 
     if result.errors:
         lines.append(f"*Errors:* {escape(str(result.errors))}")

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -673,11 +673,12 @@ def audit_process(
         "audit_process.completed",
         events_processed=result.events_processed,
         matches_resubmitted=result.matches_resubmitted,
-        extra_in_mt_flagged=result.extra_in_mt_flagged,
+        extra_in_mt_cancelled=result.extra_in_mt_cancelled,
+        extra_in_mt_skipped=result.extra_in_mt_skipped,
         errors=result.errors,
     )
 
-    if result.matches_resubmitted or result.extra_in_mt_flagged:
+    if result.matches_resubmitted or result.extra_in_mt_cancelled:
         _send_telegram_processor_report(settings=settings, result=result, env=env)
 
     structlog.contextvars.unbind_contextvars("run_id", "env")


### PR DESCRIPTION
## Summary

- Previously `extra_in_mt` findings were logged as warnings with no automated resolution — noise with no action
- Now the processor **automatically cancels** MT match records that are > 7 days old and not found on the website
- Matches within the 7-day window are left alone (reschedule lag on mlssoccer.com)
- The MT cancel endpoint refuses to touch scored matches (safety guard)
- Cancelled matches are excluded from future audit comparisons and planner counts

## Report change

Before:
```
Events processed: 1 · Resubmitted: 9 · Flagged extra: 10
```

After:
```
Corrected: 9 · Cancelled: 8 · Pending (< 7d): 2
```

## Dependencies

Requires missing-table PR: `feat/audit-cancel-match-endpoint` to be deployed first.

## Test plan
- [ ] All 109 tests pass
- [ ] Dry-run: processor logs cancellations without calling MT API
- [ ] Prod run: extra_in_mt matches > 7 days old are cancelled in MT
- [ ] Matches < 7 days old are skipped (logged as `extra_in_mt.skipped`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)