### PR TITLE
feat: Alert on extra_in_mt findings with prominent Telegram notification

### DIFF
--- a/src/audit/models.py
+++ b/src/audit/models.py
@@ -70,9 +70,18 @@ class AuditTeamStatus(BaseModel):
     findings_count: int = 0
 
 
+class ExtraInMtMatch(BaseModel):
+    home_team: str
+    away_team: str
+    match_date: str
+    team: str
+    age_group: str
+
+
 class ProcessResult(BaseModel):
     events_processed: int
     matches_resubmitted: int
     corrections_by_type: dict[str, int] = {}  # finding_type -> count of resubmitted matches
     extra_in_mt_skipped: int  # queued for human review, not auto-cancelled
+    extra_in_mt_findings: list[ExtraInMtMatch] = []
     errors: int

--- a/src/audit/processor.py
+++ b/src/audit/processor.py
@@ -8,7 +8,7 @@ import structlog
 
 from agent.tools import _current_season
 from audit.client import fetch_pending_events, mark_event_processed
-from audit.models import ProcessResult
+from audit.models import ExtraInMtMatch, ProcessResult
 
 if TYPE_CHECKING:
     from config.settings import AgentSettings
@@ -46,6 +46,7 @@ async def process_pending_events(
     matches_resubmitted = 0
     corrections_by_type: dict[str, int] = {}
     extra_in_mt_skipped = 0
+    extra_in_mt_findings: list[ExtraInMtMatch] = []
     errors = 0
 
     for event in events:
@@ -77,6 +78,15 @@ async def process_pending_events(
                     # A transient scraper failure (selector bug, site lag) would otherwise
                     # silently delete legitimate matches with no recovery path.
                     extra_in_mt_skipped += 1
+                    extra_in_mt_findings.append(
+                        ExtraInMtMatch(
+                            home_team=finding.home_team,
+                            away_team=finding.away_team,
+                            match_date=finding.match_date,
+                            team=event.team,
+                            age_group=event.age_group,
+                        )
+                    )
                     logger.info(
                         "audit.processor.extra_in_mt.skipped",
                         home_team=finding.home_team,
@@ -115,5 +125,6 @@ async def process_pending_events(
         matches_resubmitted=matches_resubmitted,
         corrections_by_type=corrections_by_type,
         extra_in_mt_skipped=extra_in_mt_skipped,
+        extra_in_mt_findings=extra_in_mt_findings,
         errors=errors,
     )

--- a/src/audit/report.py
+++ b/src/audit/report.py
@@ -74,11 +74,24 @@ def build_processor_report(result: ProcessResult, env: str) -> str:
         lines.append(corrected_line)
 
     if result.extra_in_mt_skipped:
+        lines.append("")
+        lines.append("⚠️ *MANUAL REVIEW REQUIRED* ⚠️")
         lines.append(
-            f"*Extra in MT \\(review required\\):* {escape(str(result.extra_in_mt_skipped))}"
+            f"*{escape(str(result.extra_in_mt_skipped))} match"
+            f"{'es' if result.extra_in_mt_skipped != 1 else ''}"
+            f" found in MT but NOT on mlssoccer\\.com*"
         )
+        lines.append("_Do NOT cancel without verifying — may be a scraper bug\\._")
+        lines.append("")
+        for m in result.extra_in_mt_findings:
+            home = escape(m.home_team)
+            away = escape(m.away_team)
+            md = escape(m.match_date)
+            label = escape(f"{m.team} {m.age_group}")
+            lines.append(f"  • {md} {home} vs {away} _{label}_")
 
     if result.errors:
+        lines.append("")
         lines.append(f"*Errors:* {escape(str(result.errors))}")
 
     return "\n".join(lines)

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -743,7 +743,7 @@ def audit_process(
         errors=result.errors,
     )
 
-    if result.matches_resubmitted:
+    if result.matches_resubmitted or result.extra_in_mt_skipped:
         _send_telegram_processor_report(settings=settings, result=result, env=env)
 
     structlog.contextvars.unbind_contextvars("run_id", "env")


### PR DESCRIPTION
## Summary
- Adds `ExtraInMtMatch` model to store full match detail for each `extra_in_mt` finding
- Processor populates the list so the report can name every affected match
- Telegram message now leads with `⚠️ MANUAL REVIEW REQUIRED ⚠️` and lists each match with team/age group
- Notification fires whenever `extra_in_mt_skipped > 0`, not just on resubmissions — silent runs are no longer possible when matches need review

## Test plan
- [x] All 106 tests pass
- [x] Ruff lint + format clean
- [ ] Verify Telegram message renders correctly with match list on next `extra_in_mt` finding in prod

🤖 Generated with Claude Code