### PR TITLE
fix: Add imagePullPolicy: Always to all CronJob manifests

### DIFF
--- a/k3s/audit/cronjob-audit-process.yaml
+++ b/k3s/audit/cronjob-audit-process.yaml
@@ -18,6 +18,7 @@ spec:
           containers:
             - name: agent
               image: ghcr.io/silverbeer/match-scraper-agent:latest
+              imagePullPolicy: Always
               args: ["audit-process", "--env", "prod"]
               envFrom:
                 - configMapRef:

--- a/k3s/audit/cronjob-audit.yaml
+++ b/k3s/audit/cronjob-audit.yaml
@@ -18,6 +18,7 @@ spec:
           containers:
             - name: agent
               image: ghcr.io/silverbeer/match-scraper-agent:latest
+              imagePullPolicy: Always
               args: ["audit", "--env", "prod", "--count", "10"]
               envFrom:
                 - configMapRef:

--- a/k3s/match-scraper-agent/cronjob-weekend.yaml
+++ b/k3s/match-scraper-agent/cronjob-weekend.yaml
@@ -18,6 +18,7 @@ spec:
           containers:
             - name: agent
               image: ghcr.io/silverbeer/match-scraper-agent:latest
+              imagePullPolicy: Always
               args: ["run", "--env", "prod"]
               envFrom:
                 - configMapRef:

--- a/k3s/match-scraper-agent/cronjob.yaml
+++ b/k3s/match-scraper-agent/cronjob.yaml
@@ -18,6 +18,7 @@ spec:
           containers:
             - name: agent
               image: ghcr.io/silverbeer/match-scraper-agent:latest
+              imagePullPolicy: Always
               args: ["run", "--env", "prod"]
               envFrom:
                 - configMapRef:


### PR DESCRIPTION
## Summary
- Adds `imagePullPolicy: Always` to all 4 CronJob containers (cronjob, cronjob-weekend, cronjob-audit, cronjob-audit-process)
- Without this, K3s caches the `:latest` image after first pull and never checks for updates — new deploys were silently running stale code
- Also unblocks the current deploy: after merging, run `kubectl apply` on the 4 manifests to get the latest image active on the next scheduled run

## Test plan
- [ ] Merge and apply manifests: `kubectl apply -f k3s/match-scraper-agent/cronjob.yaml -f k3s/match-scraper-agent/cronjob-weekend.yaml -f k3s/audit/cronjob-audit.yaml -f k3s/audit/cronjob-audit-process.yaml`
- [ ] Verify next job run pulls fresh image: `kubectl describe pod <pod> -n match-scraper | grep Image`

🤖 Generated with Claude Code