### PR TITLE
feat: Protect live-scored MT matches from SCORE_SYNC overwrites

### DIFF
--- a/src/agent/deps.py
+++ b/src/agent/deps.py
@@ -29,5 +29,6 @@ class RunContext:
     division: str = "Northeast"
     _scraped_matches: list[dict[str, Any]] = field(default_factory=list)
     _submission_errors: list[dict[str, str]] = field(default_factory=list)
+    _protected_matches: list[dict[str, Any]] = field(default_factory=list)
     _mt_status: str = ""  # "ok", "failed:<reason>", or "" (not called)
     _scrape_plan: Any = None  # RunPlan from planner, or None for targeted runs

--- a/src/agent/engine.py
+++ b/src/agent/engine.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from datetime import date
+from typing import Any
 
 import structlog
 
@@ -52,6 +53,34 @@ _MODIFIERS: list[Callable[[ScrapePlan, TargetEntry | None], ScrapePlan]] = [
     all_scored_skip,
     error_retry,
 ]
+
+
+# ---------------------------------------------------------------------------
+# Live-score protection
+# ---------------------------------------------------------------------------
+
+
+def _filter_live_scored_protection(
+    matches: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Separate scraped matches into submit vs. protected groups for SCORE_SYNC.
+
+    During SCORE_SYNC, only submit matches that mlssoccer.com has already scored
+    (home_score is not None). Unscored matches are withheld — they carry no new
+    information for a score sync and could overwrite live-scored MT records that
+    haven't been posted on mlssoccer.com yet.
+
+    Returns:
+        (to_submit, protected) — match dicts ready to submit, and those held back.
+    """
+    to_submit = []
+    protected = []
+    for m in matches:
+        if m.get("home_score") is not None:
+            to_submit.append(m)
+        else:
+            protected.append(m)
+    return to_submit, protected
 
 
 # ---------------------------------------------------------------------------
@@ -133,6 +162,26 @@ async def execute_plan(plan: RunPlan, ctx: RunContext) -> AgentResult:
                 dry_run=ctx.dry_run,
             )
         )
+
+        # For SCORE_SYNC: withhold unscored matches to protect live-scored MT records.
+        # mlssoccer.com may not yet reflect a score that was entered live in MT —
+        # submitting "scheduled" would overwrite the completed/scored MT record.
+        if rule.action == ScrapeAction.SCORE_SYNC and ctx._scraped_matches:
+            ctx._scraped_matches, newly_protected = _filter_live_scored_protection(
+                ctx._scraped_matches
+            )
+            ctx._protected_matches.extend(newly_protected)
+            found = len(ctx._scraped_matches)
+            if newly_protected:
+                logger.info(
+                    "engine.score_sync.protected",
+                    target=rule.target_label,
+                    protected_count=len(newly_protected),
+                    reason=(
+                        "mlssoccer.com not yet scored — withheld to protect"
+                        " potential live-scored MT data"
+                    ),
+                )
 
         if found > 0:
             submit_result = await submit_matches(ctx)

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -146,6 +146,7 @@ def _send_telegram_report(
         matches_submitted=result.matches_submitted,
         scraped_matches=ctx._scraped_matches,
         submission_errors=ctx._submission_errors,
+        protected_matches=ctx._protected_matches,
         env=env,
         target=target,
         dry_run=ctx.dry_run,

--- a/src/utils/report.py
+++ b/src/utils/report.py
@@ -24,6 +24,7 @@ def build_report(
     matches_submitted: int,
     scraped_matches: list[dict[str, Any]],
     submission_errors: list[dict[str, str]],
+    protected_matches: list[dict[str, Any]] | None = None,
     env: str,
     target: str | None,
     dry_run: bool,
@@ -144,6 +145,25 @@ def build_report(
             match = escape(err.get("match", "unknown"))
             error = escape(err.get("error", "unknown"))
             lines.append(f"  • {match} — {error}")
+        lines.append("")
+
+    # --- Live Score Protected ---
+    protected = protected_matches or []
+    if protected:
+        n = len(protected)
+        lines.append(f"*Live Score Protected \\({escape(str(n))}\\):*")
+        lines.append(
+            escape("  ⚠️ mlssoccer.com not yet updated — withheld to protect MT live scores")
+        )
+        lines.append(
+            escape("  Run 'audit' after mlssoccer.com posts scores to detect any discrepancies")
+        )
+        for m in sorted(protected, key=lambda x: x.get("match_date", "")):
+            md = escape(m.get("match_date", "?"))
+            home = escape(m.get("home_team", "?"))
+            away = escape(m.get("away_team", "?"))
+            status = escape(m.get("match_status", "?"))
+            lines.append(f"  • {md} {home} vs {away} \\[{status}\\]")
         lines.append("")
 
     # --- Weekend Scores ---

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from agent.deps import RunContext
 from agent.engine import (
+    _filter_live_scored_protection,
     all_scored_skip,
     apply_modifiers,
     error_retry,
@@ -197,6 +198,181 @@ class TestExecutePlan:
             result = asyncio.run(execute_plan(plan, ctx))
 
         assert result.actions[0].dry_run is True
+
+
+class TestFilterLiveScoredProtection:
+    def test_unscored_match_is_protected(self) -> None:
+        matches = [
+            {"home_team": "IFA", "away_team": "Team B", "home_score": None, "away_score": None,
+             "match_status": "scheduled"},
+        ]
+        to_submit, protected = _filter_live_scored_protection(matches)
+        assert to_submit == []
+        assert len(protected) == 1
+        assert protected[0]["home_team"] == "IFA"
+
+    def test_scored_match_is_submitted(self) -> None:
+        matches = [
+            {"home_team": "IFA", "away_team": "Team B", "home_score": 2, "away_score": 1,
+             "match_status": "completed"},
+        ]
+        to_submit, protected = _filter_live_scored_protection(matches)
+        assert len(to_submit) == 1
+        assert protected == []
+
+    def test_mixed_matches_split_correctly(self) -> None:
+        matches = [
+            {"home_team": "A", "away_team": "B", "home_score": 2, "away_score": 0,
+             "match_status": "completed"},
+            {"home_team": "C", "away_team": "D", "home_score": None, "away_score": None,
+             "match_status": "scheduled"},
+            {"home_team": "E", "away_team": "F", "home_score": 1, "away_score": 1,
+             "match_status": "completed"},
+        ]
+        to_submit, protected = _filter_live_scored_protection(matches)
+        assert len(to_submit) == 2
+        assert len(protected) == 1
+        assert protected[0]["home_team"] == "C"
+
+    def test_zero_score_match_is_submitted(self) -> None:
+        """A 0-0 draw has home_score=0, which is not None — should be submitted."""
+        matches = [
+            {"home_team": "A", "away_team": "B", "home_score": 0, "away_score": 0,
+             "match_status": "completed"},
+        ]
+        to_submit, protected = _filter_live_scored_protection(matches)
+        assert len(to_submit) == 1
+        assert protected == []
+
+    def test_empty_input_returns_empty_lists(self) -> None:
+        to_submit, protected = _filter_live_scored_protection([])
+        assert to_submit == []
+        assert protected == []
+
+
+class TestScoreSyncProtection:
+    """Integration tests: SCORE_SYNC withholds unscored matches, FULL_SYNC does not."""
+
+    def test_score_sync_protects_unscored_matches(self) -> None:
+        ctx = _make_ctx()
+        plan = RunPlan(plans=[_make_plan(action=ScrapeAction.SCORE_SYNC)])
+
+        mock_scrape = AsyncMock(return_value="Found 2 matches")
+        mock_submit = AsyncMock(return_value="Submitted 1 matches to queue (0 errors).")
+
+        def scrape_side_effect(ctx_arg, **kwargs):
+            ctx_arg._scraped_matches = [
+                {"home_team": "IFA", "away_team": "B", "home_score": None, "away_score": None,
+                 "match_status": "scheduled"},
+                {"home_team": "C", "away_team": "D", "home_score": 2, "away_score": 1,
+                 "match_status": "completed"},
+            ]
+            return mock_scrape(ctx_arg, **kwargs)
+
+        with (
+            patch("agent.engine.scrape_matches", side_effect=scrape_side_effect),
+            patch("agent.engine.submit_matches", mock_submit),
+        ):
+            result = asyncio.run(execute_plan(plan, ctx))
+
+        # Only the scored match should be submitted
+        assert len(ctx._scraped_matches) == 1
+        assert ctx._scraped_matches[0]["home_team"] == "C"
+        # The unscored match should be protected
+        assert len(ctx._protected_matches) == 1
+        assert ctx._protected_matches[0]["home_team"] == "IFA"
+        assert result.matches_found == 2  # total_found counts before filter
+
+    def test_score_sync_all_unscored_skips_submit(self) -> None:
+        ctx = _make_ctx()
+        plan = RunPlan(plans=[_make_plan(action=ScrapeAction.SCORE_SYNC)])
+
+        mock_scrape = AsyncMock(return_value="Found 1 match")
+        mock_submit = AsyncMock(return_value="Submitted 0 matches")
+
+        def scrape_side_effect(ctx_arg, **kwargs):
+            ctx_arg._scraped_matches = [
+                {"home_team": "IFA", "away_team": "B", "home_score": None, "away_score": None,
+                 "match_status": "scheduled"},
+            ]
+            return mock_scrape(ctx_arg, **kwargs)
+
+        with (
+            patch("agent.engine.scrape_matches", side_effect=scrape_side_effect),
+            patch("agent.engine.submit_matches", mock_submit) as mock_sub,
+        ):
+            asyncio.run(execute_plan(plan, ctx))
+
+        # submit_matches should NOT be called when nothing passes the filter
+        mock_sub.assert_not_called()
+        assert len(ctx._protected_matches) == 1
+
+    def test_full_sync_does_not_filter_unscored_matches(self) -> None:
+        ctx = _make_ctx()
+        plan = RunPlan(plans=[_make_plan(action=ScrapeAction.FULL_SYNC)])
+
+        mock_scrape = AsyncMock(return_value="Found 1 match")
+        mock_submit = AsyncMock(return_value="Submitted 1 matches to queue (0 errors).")
+
+        def scrape_side_effect(ctx_arg, **kwargs):
+            ctx_arg._scraped_matches = [
+                {"home_team": "A", "away_team": "B", "home_score": None, "away_score": None,
+                 "match_status": "scheduled"},
+            ]
+            return mock_scrape(ctx_arg, **kwargs)
+
+        with (
+            patch("agent.engine.scrape_matches", side_effect=scrape_side_effect),
+            patch("agent.engine.submit_matches", mock_submit),
+        ):
+            asyncio.run(execute_plan(plan, ctx))
+
+        # FULL_SYNC: unscored matches still submitted, nothing protected
+        assert len(ctx._protected_matches) == 0
+        mock_submit.assert_called_once()
+
+    def test_protected_matches_accumulate_across_targets(self) -> None:
+        ctx = _make_ctx()
+        plan = RunPlan(
+            plans=[
+                _make_plan(action=ScrapeAction.SCORE_SYNC, target_key="u14-hg"),
+                ScrapePlan(
+                    target_key="u15-hg",
+                    target_label="U15 Homegrown Northeast",
+                    action=ScrapeAction.SCORE_SYNC,
+                    start_date=date(2026, 3, 20),
+                    end_date=date(2026, 6, 30),
+                    reason="test",
+                    scraper_params={
+                        "age_group": "U15",
+                        "league": "Homegrown",
+                        "division": "Northeast",
+                    },
+                ),
+            ]
+        )
+
+        call_count = 0
+
+        async def scrape_side_effect(ctx_arg, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            ctx_arg._scraped_matches = [
+                {"home_team": f"Team{call_count}A", "away_team": f"Team{call_count}B",
+                 "home_score": None, "away_score": None, "match_status": "scheduled"},
+            ]
+            return f"Found 1 match (call {call_count})"
+
+        mock_submit = AsyncMock(return_value="Submitted 0 matches")
+
+        with (
+            patch("agent.engine.scrape_matches", side_effect=scrape_side_effect),
+            patch("agent.engine.submit_matches", mock_submit),
+        ):
+            asyncio.run(execute_plan(plan, ctx))
+
+        # Both targets contributed a protected match
+        assert len(ctx._protected_matches) == 2
 
 
 class TestRunPipeline:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -203,8 +203,13 @@ class TestExecutePlan:
 class TestFilterLiveScoredProtection:
     def test_unscored_match_is_protected(self) -> None:
         matches = [
-            {"home_team": "IFA", "away_team": "Team B", "home_score": None, "away_score": None,
-             "match_status": "scheduled"},
+            {
+                "home_team": "IFA",
+                "away_team": "Team B",
+                "home_score": None,
+                "away_score": None,
+                "match_status": "scheduled",
+            },
         ]
         to_submit, protected = _filter_live_scored_protection(matches)
         assert to_submit == []
@@ -213,8 +218,13 @@ class TestFilterLiveScoredProtection:
 
     def test_scored_match_is_submitted(self) -> None:
         matches = [
-            {"home_team": "IFA", "away_team": "Team B", "home_score": 2, "away_score": 1,
-             "match_status": "completed"},
+            {
+                "home_team": "IFA",
+                "away_team": "Team B",
+                "home_score": 2,
+                "away_score": 1,
+                "match_status": "completed",
+            },
         ]
         to_submit, protected = _filter_live_scored_protection(matches)
         assert len(to_submit) == 1
@@ -222,12 +232,27 @@ class TestFilterLiveScoredProtection:
 
     def test_mixed_matches_split_correctly(self) -> None:
         matches = [
-            {"home_team": "A", "away_team": "B", "home_score": 2, "away_score": 0,
-             "match_status": "completed"},
-            {"home_team": "C", "away_team": "D", "home_score": None, "away_score": None,
-             "match_status": "scheduled"},
-            {"home_team": "E", "away_team": "F", "home_score": 1, "away_score": 1,
-             "match_status": "completed"},
+            {
+                "home_team": "A",
+                "away_team": "B",
+                "home_score": 2,
+                "away_score": 0,
+                "match_status": "completed",
+            },
+            {
+                "home_team": "C",
+                "away_team": "D",
+                "home_score": None,
+                "away_score": None,
+                "match_status": "scheduled",
+            },
+            {
+                "home_team": "E",
+                "away_team": "F",
+                "home_score": 1,
+                "away_score": 1,
+                "match_status": "completed",
+            },
         ]
         to_submit, protected = _filter_live_scored_protection(matches)
         assert len(to_submit) == 2
@@ -237,8 +262,13 @@ class TestFilterLiveScoredProtection:
     def test_zero_score_match_is_submitted(self) -> None:
         """A 0-0 draw has home_score=0, which is not None — should be submitted."""
         matches = [
-            {"home_team": "A", "away_team": "B", "home_score": 0, "away_score": 0,
-             "match_status": "completed"},
+            {
+                "home_team": "A",
+                "away_team": "B",
+                "home_score": 0,
+                "away_score": 0,
+                "match_status": "completed",
+            },
         ]
         to_submit, protected = _filter_live_scored_protection(matches)
         assert len(to_submit) == 1
@@ -262,10 +292,20 @@ class TestScoreSyncProtection:
 
         def scrape_side_effect(ctx_arg, **kwargs):
             ctx_arg._scraped_matches = [
-                {"home_team": "IFA", "away_team": "B", "home_score": None, "away_score": None,
-                 "match_status": "scheduled"},
-                {"home_team": "C", "away_team": "D", "home_score": 2, "away_score": 1,
-                 "match_status": "completed"},
+                {
+                    "home_team": "IFA",
+                    "away_team": "B",
+                    "home_score": None,
+                    "away_score": None,
+                    "match_status": "scheduled",
+                },
+                {
+                    "home_team": "C",
+                    "away_team": "D",
+                    "home_score": 2,
+                    "away_score": 1,
+                    "match_status": "completed",
+                },
             ]
             return mock_scrape(ctx_arg, **kwargs)
 
@@ -292,8 +332,13 @@ class TestScoreSyncProtection:
 
         def scrape_side_effect(ctx_arg, **kwargs):
             ctx_arg._scraped_matches = [
-                {"home_team": "IFA", "away_team": "B", "home_score": None, "away_score": None,
-                 "match_status": "scheduled"},
+                {
+                    "home_team": "IFA",
+                    "away_team": "B",
+                    "home_score": None,
+                    "away_score": None,
+                    "match_status": "scheduled",
+                },
             ]
             return mock_scrape(ctx_arg, **kwargs)
 
@@ -316,8 +361,13 @@ class TestScoreSyncProtection:
 
         def scrape_side_effect(ctx_arg, **kwargs):
             ctx_arg._scraped_matches = [
-                {"home_team": "A", "away_team": "B", "home_score": None, "away_score": None,
-                 "match_status": "scheduled"},
+                {
+                    "home_team": "A",
+                    "away_team": "B",
+                    "home_score": None,
+                    "away_score": None,
+                    "match_status": "scheduled",
+                },
             ]
             return mock_scrape(ctx_arg, **kwargs)
 
@@ -358,8 +408,13 @@ class TestScoreSyncProtection:
             nonlocal call_count
             call_count += 1
             ctx_arg._scraped_matches = [
-                {"home_team": f"Team{call_count}A", "away_team": f"Team{call_count}B",
-                 "home_score": None, "away_score": None, "match_status": "scheduled"},
+                {
+                    "home_team": f"Team{call_count}A",
+                    "away_team": f"Team{call_count}B",
+                    "home_score": None,
+                    "away_score": None,
+                    "match_status": "scheduled",
+                },
             ]
             return f"Found 1 match (call {call_count})"
 


### PR DESCRIPTION
## Summary
- During SCORE_SYNC, unscored matches scraped from mlssoccer.com are now withheld from submission — only matches with `home_score != None` are submitted
- This prevents the scenario where mlssoccer.com hasn't yet posted a score, causing a live-scored 'completed' MT record (with goals, cards, lineups) to be overwritten as 'scheduled'
- Protected matches are tracked in `RunContext._protected_matches` and surfaced in the Telegram report with a prompt to run `audit` once mlssoccer.com catches up
- FULL_SYNC and KICKOFF_SYNC are unaffected — only SCORE_SYNC applies the filter

## Test plan
- [x] `TestFilterLiveScoredProtection` — unit tests for the split logic (unscored protected, scored submitted, 0-0 draws not blocked, empty input)
- [x] `TestScoreSyncProtection` — integration tests: SCORE_SYNC withholds unscored, skips `submit_matches` when nothing passes, FULL_SYNC is unaffected, protected matches accumulate across targets
- [x] All 115 tests pass

## Discrepancy process
When mlssoccer.com eventually posts a score that differs from the live score in MT, the existing `audit` → `audit-process` pipeline detects it as a `score_mismatch` finding. The Telegram protected-matches section reminds the operator to run `audit` to catch these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)