### PR TITLE
feat: Add weekly QoP rankings CronJob

### DIFF
--- a/k3s/deploy.sh
+++ b/k3s/deploy.sh
@@ -2,7 +2,8 @@
 # Deploy match-scraper-agent stack to K3s.
 #
 # Applies: namespace → RabbitMQ (pvc, deployment, service) →
-#          match-scraper-agent (configmap, secret, cronjob)
+#          match-scraper-agent (configmap, secret, cronjob) →
+#          qop-rankings (cronjob)
 #
 # Reads envs/.env.prod for secrets and generates the K8s Secret manifest.
 #
@@ -83,6 +84,10 @@ kubectl apply -f "$SCRIPT_DIR/match-scraper-agent/pvc.yaml"
 kubectl apply -f "$SCRIPT_DIR/match-scraper-agent/configmap.yaml"
 kubectl apply -f "$SECRET_FILE"
 kubectl apply -f "$SCRIPT_DIR/match-scraper-agent/cronjob.yaml"
+
+echo ""
+echo "Applying QoP rankings scraper..."
+kubectl apply -f "$SCRIPT_DIR/qop-rankings/cronjob.yaml"
 
 echo ""
 echo "Done. Verify with:"

--- a/k3s/match-scraper-agent/configmap.yaml
+++ b/k3s/match-scraper-agent/configmap.yaml
@@ -10,6 +10,7 @@ data:
   AGENT_AGE_GROUP: "U14"
   AGENT_DIVISION: "Northeast"
   AGENT_MISSING_TABLE_API_URL: "https://api.missingtable.com"
+  MISSING_TABLE_API_BASE_URL: "https://api.missingtable.com"
   AGENT_JOURNAL_S3_BUCKET: "missingtable-match-scraper"
   AGENT_JOURNAL_S3_KEY: "journal/latest.json"
   AGENT_DRY_RUN: "false"

--- a/k3s/qop-rankings/cronjob.yaml
+++ b/k3s/qop-rankings/cronjob.yaml
@@ -1,0 +1,45 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: qop-rankings-scraper
+  namespace: match-scraper
+spec:
+  schedule: "0 6 * * 1"  # Every Monday at 06:00 UTC
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 600
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: rankings-scraper
+              image: ghcr.io/silverbeer/match-scraper-agent:latest
+              imagePullPolicy: Always
+              command: ["mls-scraper"]
+              args:
+                - rankings
+                - --age-group
+                - u14
+                - --division
+                - northeast
+                - --headless
+              envFrom:
+                - configMapRef:
+                    name: match-scraper-agent-config
+                - secretRef:
+                    name: match-scraper-agent-secret
+              # Note: the configmap exposes AGENT_MISSING_TABLE_API_URL; the
+              # mls-scraper rankings command reads MISSING_TABLE_API_BASE_URL.
+              # If the command cannot find the API URL, add MISSING_TABLE_API_BASE_URL
+              # to the configmap pointing at https://api.missingtable.com.
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+                limits:
+                  cpu: "500m"
+                  memory: 1Gi


### PR DESCRIPTION
## Summary
- Adds `k3s/qop-rankings/cronjob.yaml` — a weekly CronJob that runs `mls-scraper rankings --age-group u14 --division northeast` every Monday at 06:00 UTC
- Adds `MISSING_TABLE_API_BASE_URL` to the shared configmap so the `mls-scraper rankings` command can resolve the MT API URL
- Updates `k3s/deploy.sh` to apply the new manifest

## Issues closed
Closes #60

## Schedule
Runs every Monday at 06:00 UTC (02:00 EST) — after MLS Next typically publishes updated weekly QoP rankings.

## Test plan
- [ ] Verify configmap applies cleanly: `kubectl apply -f k3s/match-scraper-agent/configmap.yaml`
- [ ] Apply CronJob: `kubectl apply -f k3s/qop-rankings/cronjob.yaml`
- [ ] Trigger a manual test run:
  ```bash
  kubectl create job --from=cronjob/qop-rankings-scraper qop-test-1 -n match-scraper
  kubectl logs -n match-scraper -l job-name=qop-test-1 --follow
  ```
- [ ] Confirm rankings appear in MT after manual run

## Merge order
Merge after both `match-scraper` and `missing-table` PRs are merged and deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)