### PR TITLE
fix: Bump mls-match-scraper to 80b533c and fix QoP CronJob spec

### DIFF
--- a/k3s/qop-rankings/cronjob.yaml
+++ b/k3s/qop-rankings/cronjob.yaml
@@ -4,7 +4,8 @@ metadata:
   name: qop-rankings-scraper
   namespace: match-scraper
 spec:
-  schedule: "0 6 * * 1"  # Every Monday at 06:00 UTC
+  schedule: "0 12 * * 5"  # Every Friday at 12:00 (noon) America/New_York
+  timeZone: "America/New_York"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 5
@@ -19,13 +20,13 @@ spec:
             - name: rankings-scraper
               image: ghcr.io/silverbeer/match-scraper-agent:latest
               imagePullPolicy: Always
-              command: ["mls-scraper"]
+              command: ["uv", "run", "mls-scraper"]
               args:
                 - rankings
                 - --age-group
-                - u14
+                - U14
                 - --division
-                - northeast
+                - Northeast
                 - --headless
               envFrom:
                 - configMapRef:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Pipeline-based match data manager — deterministic rules engine for youth soccer scraping"
 requires-python = ">=3.12"
 dependencies = [
-    "mls-match-scraper @ git+https://github.com/silverbeer/match-scraper.git@162f911",
+    "mls-match-scraper @ git+https://github.com/silverbeer/match-scraper.git@80b533c",
     "typer>=0.15",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",


### PR DESCRIPTION
## Summary
- Bumps `mls-match-scraper` pin from `162f911` → `80b533c` to pick up [PR #64](https://github.com/silverbeer/match-scraper/pull/64), which rewrites the QoP scraper to use the modular11 `get_teams` endpoint + BeautifulSoup. The old version tried to interact with a Playwright division-filter control that doesn't exist on the page — every run failed with `Division filter not found for 'Northeast'`.
- Fixes the QoP CronJob manifest:
  - `command: ["uv", "run", "mls-scraper"]` — bare `mls-scraper` is not on PATH; the venv binary lives at `/app/.venv/bin/mls-scraper`.
  - `--age-group U14 --division Northeast` — the CLI args are case-sensitive and must match the library's defaults.
  - Schedule now Friday noon `America/New_York` (via cron `timeZone` so DST is handled).

## Test plan
- [x] `uv sync` picks up the new pin cleanly
- [x] Full test suite passes (`cd tests && uv run pytest -q` → 115 passed)
- [x] Ruff check + format pass
- [ ] After merge + CI image rebuild, trigger a manual Job from the `qop-rankings-scraper` CronJob and verify rankings POST to the MT API

🤖 Generated with [Claude Code](https://claude.com/claude-code)