### PR TITLE
fix: Map MISSING_TABLE_API_{BASE_URL,TOKEN} into QoP CronJob env

### DIFF
--- a/k3s/qop-rankings/cronjob.yaml
+++ b/k3s/qop-rankings/cronjob.yaml
@@ -33,10 +33,19 @@ spec:
                     name: match-scraper-agent-config
                 - secretRef:
                     name: match-scraper-agent-secret
-              # Note: the configmap exposes AGENT_MISSING_TABLE_API_URL; the
-              # mls-scraper rankings command reads MISSING_TABLE_API_BASE_URL.
-              # If the command cannot find the API URL, add MISSING_TABLE_API_BASE_URL
-              # to the configmap pointing at https://api.missingtable.com.
+              env:
+                # The mls-scraper rankings command reads these unprefixed names;
+                # we map them from the agent's AGENT_-prefixed equivalents.
+                - name: MISSING_TABLE_API_BASE_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: match-scraper-agent-config
+                      key: AGENT_MISSING_TABLE_API_URL
+                - name: MISSING_TABLE_API_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: match-scraper-agent-secret
+                      key: AGENT_MISSING_TABLE_API_KEY
               resources:
                 requests:
                   cpu: 100m


### PR DESCRIPTION
## Summary
- The `mls-scraper rankings` command reads `MISSING_TABLE_API_BASE_URL` and `MISSING_TABLE_API_TOKEN` (unprefixed), but the agent's configmap/secret expose them as `AGENT_MISSING_TABLE_API_URL` / `AGENT_MISSING_TABLE_API_KEY`. Without mapping, the scrape succeeds but the POST fails with `--api-token / MISSING_TABLE_API_TOKEN is required to POST rankings`.
- Uses `valueFrom` refs in the pod env to rename the existing values. No secret/configmap duplication.

## Test plan
- [x] Manifest applied to cluster; one-off Job completed in 12s
- [x] Scraped 22 U14 Northeast teams (matches the MLS Next page exactly — NYC FC #1 @ 87.6 QoP through Oakwood #22 @ 65.0)
- [x] POST succeeded: `Posted 22 rankings to MT API for week of 2026-04-13 ✓`

🤖 Generated with [Claude Code](https://claude.com/claude-code)