### PR TITLE
chore: Bump mls-match-scraper to fadd4b9 (QoP team-name normalization)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Pipeline-based match data manager — deterministic rules engine for youth soccer scraping"
 requires-python = ">=3.12"
 dependencies = [
-    "mls-match-scraper @ git+https://github.com/silverbeer/match-scraper.git@80b533c",
+    "mls-match-scraper @ git+https://github.com/silverbeer/match-scraper.git@fadd4b9",
     "typer>=0.15",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",


### PR DESCRIPTION
## Summary
- Bumps `mls-match-scraper` pin from `80b533c` → `fadd4b9` to pick up [PR #65](https://github.com/silverbeer/match-scraper/pull/65), which applies the existing `normalize_team_name_for_display` mapping to each QoP ranking before the MT POST.
- Resolves the blank QoP cell for IFA on the Homegrown Northeast standings page — previously the POST carried `Intercontinental Football Academy of New England` which MT couldn't resolve to `team_id`.

## Test plan
- [x] `uv sync` picks up the new pin cleanly
- [x] Full test suite passes (`cd tests && uv run pytest -q` → 115 passed)
- [ ] After merge + CI image rebuild, trigger a manual QoP Job and verify the MT API returns a non-null `team_id` for IFA

🤖 Generated with [Claude Code](https://claude.com/claude-code)