### PR TITLE
chore: Bump mls-match-scraper to 430564f (QoP detected_at)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Pipeline-based match data manager — deterministic rules engine for youth soccer scraping"
 requires-python = ">=3.12"
 dependencies = [
-    "mls-match-scraper @ git+https://github.com/silverbeer/match-scraper.git@fadd4b9",
+    "mls-match-scraper @ git+https://github.com/silverbeer/match-scraper.git@430564f",
     "typer>=0.15",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",


### PR DESCRIPTION
## Summary
- Bumps `mls-match-scraper` pin from `fadd4b9` → `430564f` to pick up [PR #66](https://github.com/silverbeer/match-scraper/pull/66), which renames `QoPSnapshot.week_of` → `detected_at` and aligns the POST payload with MT's new snapshot-centric schema ([missing-table #306](https://github.com/silverbeer/missing-table/pull/306)).
- The scraper now emits `detected_at = date.today()` and surfaces MT's `{"status": "unchanged"}` response distinctly when no change is detected.

## Test plan
- [x] `uv sync` clean against new pin
- [x] Full agent test suite passes (`cd tests && uv run pytest -q` → 115 passed)
- [ ] After merge + CI image rebuild, trigger a manual QoP Job and verify MT returns `status: inserted` first time, then `status: unchanged` on a same-day re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)