### PR TITLE
feat: Unattended schedule release watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ All settings use the `AGENT_` prefix.
 | `AGENT_DRY_RUN` | `false` | Skip mutating operations |
 | `AGENT_JSON_LOGS` | `false` | Output structured JSON log lines |
 | `AGENT_LOG_LEVEL` | `info` | Minimum log level |
+| `AGENT_JOURNAL_S3_BUCKET` | *(empty)* | S3 bucket for cross-run state (run journal and release watcher) |
+| `AGENT_JOURNAL_S3_KEY` | `journal/latest.json` | Object key for the run journal |
+| `AGENT_RELEASE_WATCH_S3_KEY` | `release-watch/state.json` | Object key for release-watcher state |
+| `AGENT_RELEASE_WATCH_FAILURE_THRESHOLD` | `3` | Consecutive all-failed probes before alerting |
 
 ## CLI Reference
 
@@ -127,6 +131,45 @@ Options:
   --env TEXT       Environment name: local, prod (default: local)
   --proxy-url TEXT Override AGENT_PROXY_BASE_URL
 ```
+
+### `match-scraper-agent watch-release`
+
+Watch for MLS Next publishing its schedule, and announce it exactly once.
+
+Runs unattended on the `schedule-release-watch` CronJob (every 30 min). It
+never scrapes — a new season's page format is unverified until a human looks
+at it, and publishing bad data to missing-table unattended is worse than
+waiting. Notify-only by design.
+
+```
+Options:
+  --env TEXT        Environment name: local, prod (default: local)
+  --age-group, -a   Age group to check; repeat for several (default: all six, U15 first)
+  --division,  -d   Division to check; repeat for several (default: Northeast, Florida, Mid-Atlantic)
+  --full-season     Search the whole season, not just the fall segment
+  --dry-run         Probe and report, but send and save nothing
+```
+
+Exit codes double as the CronJob's outcome signal:
+
+| Code | Meaning | Telegram |
+|------|---------|----------|
+| `0`  | Nothing new — not published, or already announced | silent |
+| `10` | Newly published fixtures | 🎉 announcement |
+| `20` | Every target failed to probe | ⚠️ only once the streak hits `AGENT_RELEASE_WATCH_FAILURE_THRESHOLD` (default 3) |
+
+The CronJob maps `10` and `20` back to a zero exit, because Kubernetes reads
+any non-zero as a failed Job — which would retry and clutter the history on
+exactly the runs that worked. Anything else is treated as a real crash.
+
+**State lives in S3**, not on disk (`AGENT_RELEASE_WATCH_S3_KEY`, sharing
+`AGENT_JOURNAL_S3_BUCKET`). CronJob pods are ephemeral, so local state would
+make the watcher re-announce the same release every 30 minutes. If the bucket
+is unset the command still runs, logs a warning, and announces every time.
+
+Season changes clear the remembered targets — otherwise last season's
+announcements would suppress this season's and the watcher would go
+permanently quiet.
 
 ## Agent Tools
 
@@ -159,6 +202,16 @@ Manifests are in `k3s/match-scraper-agent/`:
 kubectl apply -f k3s/match-scraper-agent/configmap.yaml
 kubectl apply -f k3s/match-scraper-agent/secret.yaml
 kubectl apply -f k3s/match-scraper-agent/cronjob.yaml
+kubectl apply -f k3s/release-watch/cronjob.yaml
 ```
 
+Or apply the whole stack with `k3s/deploy.sh`.
+
 The CronJob runs 4x/day at 02:00, 08:00, 14:00, 20:00 UTC with `concurrencyPolicy: Forbid`.
+
+| CronJob | Schedule | Purpose |
+|---------|----------|---------|
+| `match-scraper-agent` | `0 2,8,14,20 * * *` | Scrape and submit matches |
+| `match-scraper-agent-weekend` | `0 5,11,17,23 * * 0,6` | 4 extra Sat/Sun slots |
+| `qop-rankings-scraper` | `0 12 * * 5` | Weekly QoP standings |
+| `schedule-release-watch` | `*/30 * * * *` | Watch for schedule publication (HTTP only, no browser) |

--- a/k3s/deploy.sh
+++ b/k3s/deploy.sh
@@ -3,7 +3,7 @@
 #
 # Applies: namespace → RabbitMQ (pvc, deployment, service) →
 #          match-scraper-agent (configmap, secret, cronjob) →
-#          qop-rankings (cronjob)
+#          qop-rankings (cronjob) → release-watch (cronjob)
 #
 # Reads envs/.env.prod for secrets and generates the K8s Secret manifest.
 #
@@ -88,6 +88,10 @@ kubectl apply -f "$SCRIPT_DIR/match-scraper-agent/cronjob.yaml"
 echo ""
 echo "Applying QoP rankings scraper..."
 kubectl apply -f "$SCRIPT_DIR/qop-rankings/cronjob.yaml"
+
+echo ""
+echo "Applying schedule release watcher..."
+kubectl apply -f "$SCRIPT_DIR/release-watch/cronjob.yaml"
 
 echo ""
 echo "Done. Verify with:"

--- a/k3s/match-scraper-agent/configmap.yaml
+++ b/k3s/match-scraper-agent/configmap.yaml
@@ -13,6 +13,9 @@ data:
   MISSING_TABLE_API_BASE_URL: "https://api.missingtable.com"
   AGENT_JOURNAL_S3_BUCKET: "missingtable-match-scraper"
   AGENT_JOURNAL_S3_KEY: "journal/latest.json"
+  # Schedule release watcher — shares the journal bucket. Without remote
+  # state the watcher would re-announce a release on every CronJob run.
+  AGENT_RELEASE_WATCH_S3_KEY: "release-watch/state.json"
   AGENT_DRY_RUN: "false"
   AGENT_JSON_LOGS: "true"
   AGENT_AUDIT_SEASON_START: "2026-02-01"

--- a/k3s/release-watch/cronjob.yaml
+++ b/k3s/release-watch/cronjob.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: schedule-release-watch
+  namespace: match-scraper
+spec:
+  # Every 30 minutes. A probe is ~18 HTTP requests and finishes in a couple of
+  # seconds, so this is cheap; the point is to catch a release that lands on a
+  # weekend when nobody is watching.
+  schedule: "*/30 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  # Keep more failures than successes — a failed watcher is the interesting case.
+  failedJobsHistoryLimit: 5
+  # Runs every 30 min; do not let missed slots pile up after an outage.
+  startingDeadlineSeconds: 600
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 300
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: release-watch
+              image: ghcr.io/silverbeer/match-scraper-agent:latest
+              imagePullPolicy: Always
+              # Override the image ENTRYPOINT so we can translate exit codes.
+              # watch-release uses 10 (newly published) and 20 (sustained
+              # outage) to signal *outcomes*, but Kubernetes reads any non-zero
+              # exit as a failed Job — which would retry the run and clutter the
+              # history on the very occasions the watcher worked correctly.
+              # Telegram has already been sent by the time we get here, so these
+              # are reported, not failed. Anything else is a genuine crash and
+              # is left to fail.
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  uv run match-scraper-agent watch-release --env prod
+                  code=$?
+                  case "$code" in
+                    0)  echo "watch: nothing new" ;;
+                    10) echo "watch: schedule published — notified" ;;
+                    20) echo "watch: probe failing — notified if sustained" ;;
+                    *)  echo "watch: unexpected exit $code"; exit "$code" ;;
+                  esac
+              envFrom:
+                - configMapRef:
+                    name: match-scraper-agent-config
+                - secretRef:
+                    name: match-scraper-agent-secret
+              resources:
+                # No browser — plain HTTP, so this is far lighter than the
+                # scraper CronJobs.
+                requests:
+                  cpu: 50m
+                  memory: 256Mi
+                limits:
+                  cpu: "250m"
+                  memory: 512Mi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Pipeline-based match data manager — deterministic rules engine for youth soccer scraping"
 requires-python = ">=3.12"
 dependencies = [
-    "mls-match-scraper @ git+https://github.com/silverbeer/match-scraper.git@430564f",
+    "mls-match-scraper @ git+https://github.com/silverbeer/match-scraper.git@171311344925a0d6b71c5956d3defe1e7a6ef545",
     "typer>=0.15",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",

--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -6,6 +6,7 @@ import asyncio
 from datetime import date
 
 import structlog
+from src.scraper.modular11 import current_season_year, season_label, season_window
 
 from agent.deps import RunContext
 
@@ -34,7 +35,12 @@ def _normalize_team_name(name: str, *, league: str = "") -> str:
 
 # Season end date — enforced as a floor for end_date so we can't
 # accidentally use a shorter range than the full remaining season.
-SEASON_END = date(2026, 6, 30)
+#
+# Derived, not pinned. The previous hardcoded date(2026, 6, 30) silently
+# became a date in the *past* when the 2026-2027 season opened, which made
+# this floor produce an end_date before the start_date. Deriving it from the
+# current season means the rollover is a no-op instead of an outage.
+SEASON_END = season_window(current_season_year())[1]
 
 
 async def scrape_matches(
@@ -192,9 +198,11 @@ async def submit_matches(ctx: RunContext) -> str:
 
 
 def _current_season() -> str:
-    """Return the current season string (e.g. '2025-2026')."""
-    today = date.today()
-    # Season starts in August: Aug 2025 → "2025-2026", Jan 2026 → "2025-2026"
-    if today.month >= 8:
-        return f"{today.year}-{today.year + 1}"
-    return f"{today.year - 1}-{today.year}"
+    """
+    Return the current season string (e.g. '2026-2027').
+
+    Delegates to match-scraper rather than reimplementing the August cutoff.
+    Two copies of this rule is how the agent and the scraper ended up posting
+    different season formats ('2025-2026' vs '2024-25') for the same match.
+    """
+    return season_label(current_season_year())

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -834,3 +834,159 @@ def audit_report(
         f"\nTotal: {total}  |  Audited this week: {audited_week}"
         f"  |  Overdue: {overdue_count}  |  Pending: {never_count}\n"
     )
+
+
+def _send_telegram_message(settings: AgentSettings, message: str, *, subject: str) -> None:
+    """
+    Send one MarkdownV2 message, falling back to email if Telegram fails.
+
+    Mirrors _send_telegram_report but takes a prebuilt message, since the
+    release watcher has nothing to do with run summaries.
+    """
+    if not settings.telegram_bot_token or not settings.telegram_chat_id:
+        logger.debug("telegram.skipped", reason="not configured")
+        return
+
+    from telegram_notify import TelegramClient
+
+    try:
+        client = TelegramClient(
+            bot_token=settings.telegram_bot_token,
+            chat_id=settings.telegram_chat_id,
+        )
+        client.send(message)
+        logger.info("telegram.sent", chat_id=settings.telegram_chat_id)
+    except Exception as exc:
+        logger.warning("telegram.failed", error=str(exc))
+        _send_email_alert(
+            settings,
+            subject=subject,
+            body=f"Telegram notification failed: {exc}\n\n{message}",
+        )
+
+
+@app.command(name="watch-release")
+def watch_release(
+    env: Annotated[str, typer.Option("--env", help="Environment name (local, prod)")] = "local",
+    age_groups: Annotated[
+        list[str] | None,
+        typer.Option("--age-group", "-a", help="Age group to check; repeat for several."),
+    ] = None,
+    divisions: Annotated[
+        list[str] | None,
+        typer.Option("--division", "-d", help="Division to check; repeat for several."),
+    ] = None,
+    full_season: Annotated[
+        bool, typer.Option("--full-season", help="Search the whole season, not just the fall.")
+    ] = False,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Probe and report, but send and save nothing."),
+    ] = False,
+) -> None:
+    """
+    Watch for the MLS Next schedule being published, and announce it once.
+
+    Designed to run unattended on a CronJob. Sends Telegram on the first
+    detection of each target and on a sustained probe outage; stays silent
+    otherwise, because "still not published" is the expected state for weeks.
+
+    Notify-only by design — it never scrapes. A new season's page format is
+    unverified until a human looks at it, and publishing bad data to
+    missing-table unattended is worse than waiting.
+    """
+    from src.scraper.release_detector import ReleaseDetectorError, ScheduleReleaseDetector
+
+    from config.settings import AgentSettings, env_file_path
+    from utils.logger import configure_logging
+    from utils.release_watch import read_state, write_state
+    from utils.report import build_release_failure_report, build_release_report
+
+    settings = AgentSettings(_env_file=env_file_path(env))
+    configure_logging(json_output=settings.json_logs)
+
+    try:
+        detector = ScheduleReleaseDetector(
+            age_groups=age_groups or None,
+            divisions=divisions or None,
+            fall_only=not full_season,
+        )
+    except ReleaseDetectorError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    import asyncio
+
+    probe = asyncio.run(detector.probe())
+
+    bucket = settings.journal_s3_bucket
+    if bucket and not dry_run:
+        state = read_state(bucket, settings.release_watch_s3_key)
+    else:
+        if not bucket:
+            logger.warning(
+                "release_watch.no_bucket",
+                detail="AGENT_JOURNAL_S3_BUCKET unset — every run will re-announce",
+            )
+        from utils.release_watch import ReleaseWatchState
+
+        state = ReleaseWatchState()
+
+    state.reset_for_season(probe.season)
+
+    live_labels = [r.label for r in probe.live]
+    newly_live = state.newly_live(live_labels)
+
+    typer.echo(probe.summary())
+
+    if probe.all_failed:
+        state.consecutive_failures += 1
+        threshold = settings.release_watch_failure_threshold
+        logger.warning(
+            "release_watch.all_failed",
+            consecutive=state.consecutive_failures,
+            threshold=threshold,
+        )
+        if state.consecutive_failures >= threshold and not state.failure_alert_sent:
+            sample = probe.errors[0].error if probe.errors else "unknown"
+            if not dry_run:
+                _send_telegram_message(
+                    settings,
+                    build_release_failure_report(
+                        season=probe.season,
+                        consecutive_failures=state.consecutive_failures,
+                        total_targets=len(probe.results),
+                        sample_error=sample or "unknown",
+                    ),
+                    subject="[match-scraper-agent] Schedule watch failing",
+                )
+            state.failure_alert_sent = True
+    else:
+        state.consecutive_failures = 0
+        state.failure_alert_sent = False
+
+    if newly_live:
+        logger.info("release_watch.released", targets=newly_live)
+        if not dry_run:
+            _send_telegram_message(
+                settings,
+                build_release_report(
+                    season=probe.season,
+                    newly_live=newly_live,
+                    window_start=probe.window_start.isoformat(),
+                    window_end=probe.window_end.isoformat(),
+                    total_targets=len(probe.results),
+                ),
+                subject="[match-scraper-agent] MLS Next schedule published",
+            )
+        state.record_live(newly_live)
+
+    state.touch()
+
+    if bucket and not dry_run:
+        write_state(bucket, settings.release_watch_s3_key, state)
+
+    if probe.all_failed:
+        raise typer.Exit(code=20)
+    if newly_live:
+        raise typer.Exit(code=10)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -51,6 +51,14 @@ class AgentSettings(BaseSettings):
     journal_s3_bucket: str = ""
     journal_s3_key: str = "journal/latest.json"
 
+    # Schedule release watcher — shares the journal bucket. State must be
+    # remote because CronJob pods are ephemeral and local state would make
+    # the watcher re-announce a release on every single run.
+    release_watch_s3_key: str = "release-watch/state.json"
+    # Consecutive all-targets-failed runs before alerting. One failed run
+    # against someone else's server is noise, not news.
+    release_watch_failure_threshold: int = 3
+
     # Telegram notifications (run summary report)
     telegram_bot_token: str = ""
     telegram_chat_id: str = ""

--- a/src/utils/release_watch.py
+++ b/src/utils/release_watch.py
@@ -1,0 +1,115 @@
+"""
+Cross-run state for the schedule release watcher.
+
+CronJob pods are ephemeral, so "have we already announced this?" cannot live
+on local disk — a fresh pod would re-announce on every run, which is exactly
+the alert spam the watcher exists to avoid. State goes to S3 alongside the run
+journal.
+
+Mirrors ``utils.journal``: lazy boto3 import, and reads/writes that log and
+carry on rather than raising. A watcher that dies because S3 hiccuped is worse
+than one that sends a duplicate message.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import structlog
+from pydantic import BaseModel, Field
+
+logger = structlog.get_logger()
+
+
+class ReleaseWatchState(BaseModel):
+    """What the watcher remembers between runs."""
+
+    seen_live: list[str] = Field(
+        default_factory=list,
+        description="Target labels ('U15 Northeast') already announced as published",
+    )
+    consecutive_failures: int = Field(
+        default=0,
+        ge=0,
+        description="Runs in a row where every target failed to probe",
+    )
+    failure_alert_sent: bool = Field(
+        default=False,
+        description="Whether the current failure streak has already been alerted",
+    )
+    last_probe_at: str = Field(
+        default="", description="ISO 8601 UTC timestamp of the last completed probe"
+    )
+    last_season: str = Field(default="", description="Season the remembered targets belong to")
+
+    def newly_live(self, live_labels: list[str]) -> list[str]:
+        """Return the labels that are live now and were not live before."""
+        known = set(self.seen_live)
+        return [label for label in live_labels if label not in known]
+
+    def record_live(self, labels: list[str]) -> None:
+        """Remember these targets as announced, keeping the list stable-sorted."""
+        self.seen_live = sorted(set(self.seen_live) | set(labels))
+
+    def reset_for_season(self, season: str) -> None:
+        """
+        Drop remembered targets when the season changes.
+
+        Without this, last season's announcements would suppress this season's
+        — the watcher would go permanently quiet after its first success.
+        """
+        if self.last_season and self.last_season != season:
+            logger.info(
+                "release_watch.season_changed",
+                previous=self.last_season,
+                current=season,
+            )
+            self.seen_live = []
+            self.consecutive_failures = 0
+            self.failure_alert_sent = False
+        self.last_season = season
+
+    def touch(self, now: datetime | None = None) -> None:
+        """Stamp the probe time."""
+        self.last_probe_at = (now or datetime.now(tz=UTC)).isoformat()
+
+
+def read_state(bucket: str, key: str) -> ReleaseWatchState:
+    """
+    Read watch state from S3.
+
+    Returns a blank state when the object is missing or unreadable — the
+    watcher should start announcing again rather than refuse to run.
+    """
+    import boto3
+    from botocore.exceptions import ClientError
+
+    try:
+        s3 = boto3.client("s3")
+        response = s3.get_object(Bucket=bucket, Key=key)
+        return ReleaseWatchState.model_validate_json(response["Body"].read())
+    except ClientError as exc:
+        code = exc.response["Error"]["Code"]
+        reason = "not found" if code == "NoSuchKey" else str(exc)
+        logger.debug("release_watch.read_skipped", bucket=bucket, key=key, reason=reason)
+        return ReleaseWatchState()
+    except Exception as exc:
+        logger.debug("release_watch.read_skipped", bucket=bucket, key=key, reason=str(exc))
+        return ReleaseWatchState()
+
+
+def write_state(bucket: str, key: str, state: ReleaseWatchState) -> None:
+    """Write watch state to S3. Never raises."""
+    import boto3
+
+    try:
+        s3 = boto3.client("s3")
+        s3.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=state.model_dump_json(indent=2),
+            ContentType="application/json",
+        )
+        logger.info("release_watch.written", bucket=bucket, key=key)
+    except Exception as exc:
+        logger.warning("release_watch.write_failed", bucket=bucket, key=key, error=str(exc))

--- a/src/utils/report.py
+++ b/src/utils/report.py
@@ -363,3 +363,67 @@ def _format_delta(delta: timedelta) -> str:
 def _action_icon(action: str) -> str:
     """Map action type to an emoji icon."""
     return {"scrape": "✅", "submit": "✅", "skip": "⏭️"}.get(action, "•")
+
+
+def build_release_report(
+    *,
+    season: str,
+    newly_live: list[str],
+    window_start: str,
+    window_end: str,
+    total_targets: int,
+) -> str:
+    """
+    Build the MarkdownV2 message announcing a schedule release.
+
+    Deliberately short and actionable: this fires once, possibly at 3am, and
+    the only thing the reader needs is what dropped and what to do about it.
+    """
+    lines = [
+        "🎉 *MLS Next schedule published*",
+        "",
+        f"Season: {escape(season)}",
+        f"Window: {escape(window_start)} → {escape(window_end)}",
+        "",
+        f"*Live now* \\({len(newly_live)} of {total_targets} targets\\):",
+    ]
+    lines.extend(f"  • {escape(label)}" for label in newly_live)
+    lines += [
+        "",
+        escape(
+            "Next: verify a scrape before trusting it, then discover/enrich "
+            "any division whose clubs are not yet in missing-table."
+        ),
+    ]
+    return "\n".join(lines)
+
+
+def build_release_failure_report(
+    *,
+    season: str,
+    consecutive_failures: int,
+    total_targets: int,
+    sample_error: str,
+) -> str:
+    """
+    Build the MarkdownV2 message for a sustained probe outage.
+
+    Only sent once per streak. A single failed run is not news — the endpoint
+    is someone else's server and blips are expected.
+    """
+    return "\n".join(
+        [
+            "⚠️ *Schedule watch failing*",
+            "",
+            f"Season: {escape(season)}",
+            escape(
+                f"All {total_targets} targets have failed {consecutive_failures} runs in a row."
+            ),
+            "",
+            f"Latest error: {escape(sample_error)}",
+            "",
+            escape(
+                "The watcher cannot tell whether the schedule has dropped while this persists."
+            ),
+        ]
+    )

--- a/tests/test_release_watch.py
+++ b/tests/test_release_watch.py
@@ -1,0 +1,301 @@
+"""
+Tests for the schedule release watcher (SB-538).
+
+The watcher runs unattended for days at a time, so the behaviour that matters
+is when it stays *quiet*. Most of these tests assert that nothing was sent.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+from src.models.schedule_release import DivisionRelease, ReleaseProbe, ReleaseState
+from typer.testing import CliRunner
+
+from cli.main import app
+from utils.release_watch import ReleaseWatchState, read_state, write_state
+
+BUCKET = "missingtable-match-scraper"
+KEY = "release-watch/state.json"
+
+runner = CliRunner()
+
+
+def _result(age="U15", division="Northeast", state=ReleaseState.EMPTY, count=0, error=None):
+    return DivisionRelease(
+        age_group=age, division=division, state=state, match_count=count, error=error
+    )
+
+
+def _probe(results, season="2026-2027"):
+    return ReleaseProbe(
+        season=season,
+        window_start=date(2026, 8, 1),
+        window_end=date(2026, 12, 31),
+        checked_at=datetime(2026, 8, 7, 12, 0, tzinfo=UTC),
+        results=results,
+    )
+
+
+# ---------------------------------------------------------------------------
+# State model
+# ---------------------------------------------------------------------------
+
+
+class TestReleaseWatchState:
+    def test_everything_is_new_on_a_blank_state(self):
+        state = ReleaseWatchState()
+        assert state.newly_live(["U15 Northeast"]) == ["U15 Northeast"]
+
+    def test_remembered_targets_are_not_new(self):
+        state = ReleaseWatchState(seen_live=["U15 Northeast"])
+        assert state.newly_live(["U15 Northeast"]) == []
+
+    def test_only_the_unseen_targets_are_new(self):
+        state = ReleaseWatchState(seen_live=["U15 Northeast"])
+        assert state.newly_live(["U15 Northeast", "U15 Florida"]) == ["U15 Florida"]
+
+    def test_record_live_deduplicates(self):
+        state = ReleaseWatchState(seen_live=["U15 Northeast"])
+        state.record_live(["U15 Northeast", "U15 Florida"])
+        assert state.seen_live == ["U15 Florida", "U15 Northeast"]
+
+    def test_season_change_clears_memory(self):
+        """Otherwise the watcher goes permanently quiet after its first season."""
+        state = ReleaseWatchState(
+            seen_live=["U15 Northeast"],
+            last_season="2025-2026",
+            consecutive_failures=2,
+            failure_alert_sent=True,
+        )
+        state.reset_for_season("2026-2027")
+
+        assert state.seen_live == []
+        assert state.consecutive_failures == 0
+        assert state.failure_alert_sent is False
+        assert state.last_season == "2026-2027"
+
+    def test_same_season_keeps_memory(self):
+        state = ReleaseWatchState(seen_live=["U15 Northeast"], last_season="2026-2027")
+        state.reset_for_season("2026-2027")
+        assert state.seen_live == ["U15 Northeast"]
+
+    def test_first_ever_run_records_the_season_without_clearing(self):
+        state = ReleaseWatchState(seen_live=["U15 Northeast"])
+        state.reset_for_season("2026-2027")
+        assert state.seen_live == ["U15 Northeast"]
+        assert state.last_season == "2026-2027"
+
+    def test_touch_stamps_probe_time(self):
+        state = ReleaseWatchState()
+        state.touch(datetime(2026, 8, 7, 12, 0, tzinfo=UTC))
+        assert state.last_probe_at.startswith("2026-08-07T12:00")
+
+
+# ---------------------------------------------------------------------------
+# S3 round trip
+# ---------------------------------------------------------------------------
+
+
+class TestS3State:
+    def test_round_trip(self):
+        state = ReleaseWatchState(seen_live=["U15 Northeast"], last_season="2026-2027")
+        captured = {}
+
+        s3 = MagicMock()
+        s3.put_object.side_effect = lambda **kw: captured.update(kw)
+
+        with patch("boto3.client", return_value=s3):
+            write_state(BUCKET, KEY, state)
+
+        body = captured["Body"]
+        s3_read = MagicMock()
+        s3_read.get_object.return_value = {"Body": MagicMock(read=lambda: body)}
+
+        with patch("boto3.client", return_value=s3_read):
+            restored = read_state(BUCKET, KEY)
+
+        assert restored.seen_live == ["U15 Northeast"]
+        assert restored.last_season == "2026-2027"
+
+    def test_missing_object_yields_blank_state(self):
+        s3 = MagicMock()
+        s3.get_object.side_effect = ClientError(
+            {"Error": {"Code": "NoSuchKey", "Message": "nope"}}, "GetObject"
+        )
+
+        with patch("boto3.client", return_value=s3):
+            assert read_state(BUCKET, KEY).seen_live == []
+
+    def test_unreadable_state_yields_blank_rather_than_raising(self):
+        """A watcher that crashes on bad state stops watching entirely."""
+        s3 = MagicMock()
+        s3.get_object.return_value = {"Body": MagicMock(read=lambda: b"not json")}
+
+        with patch("boto3.client", return_value=s3):
+            assert read_state(BUCKET, KEY).seen_live == []
+
+    def test_write_failure_never_raises(self):
+        s3 = MagicMock()
+        s3.put_object.side_effect = RuntimeError("S3 is down")
+
+        with patch("boto3.client", return_value=s3):
+            write_state(BUCKET, KEY, ReleaseWatchState())  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# The command
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sent():
+    """Capture Telegram messages instead of sending them."""
+    messages: list[str] = []
+    with patch(
+        "cli.main._send_telegram_message",
+        side_effect=lambda settings, message, *, subject: messages.append(message),
+    ):
+        yield messages
+
+
+def _run(probe, state, sent_bucket="bucket", extra_args=()):
+    """Invoke watch-release against a canned probe and in-memory state."""
+    saved: dict = {}
+
+    with (
+        patch(
+            "src.scraper.release_detector.ScheduleReleaseDetector.probe",
+            new=MagicMock(return_value=_async(probe)),
+        ),
+        patch("utils.release_watch.read_state", return_value=state),
+        patch(
+            "utils.release_watch.write_state",
+            side_effect=lambda b, k, s: saved.update({"state": s}),
+        ),
+        # AgentSettings reads AGENT_-prefixed env vars; the field itself is a
+        # pydantic-settings descriptor and cannot be patched as an attribute.
+        patch.dict("os.environ", {"AGENT_JOURNAL_S3_BUCKET": sent_bucket}),
+    ):
+        result = runner.invoke(app, ["watch-release", *extra_args])
+    return result, saved.get("state")
+
+
+def _async(value):
+    """Wrap a value in an awaitable, since probe() is async."""
+
+    async def _coro():
+        return value
+
+    return _coro()
+
+
+class TestWatchReleaseCommand:
+    def test_quiet_when_nothing_published(self, sent):
+        result, state = _run(_probe([_result()]), ReleaseWatchState())
+
+        assert result.exit_code == 0
+        assert sent == [], "an unpublished schedule is not news"
+        assert state.seen_live == []
+
+    def test_announces_a_new_release_once(self, sent):
+        probe = _probe([_result(state=ReleaseState.LIVE, count=25)])
+        result, state = _run(probe, ReleaseWatchState())
+
+        assert result.exit_code == 10
+        assert len(sent) == 1
+        assert "schedule published" in sent[0].lower()
+        assert state.seen_live == ["U15 Northeast"]
+
+    def test_does_not_re_announce_a_known_release(self, sent):
+        probe = _probe([_result(state=ReleaseState.LIVE, count=25)])
+        state_in = ReleaseWatchState(seen_live=["U15 Northeast"], last_season="2026-2027")
+
+        result, _ = _run(probe, state_in)
+
+        assert result.exit_code == 0
+        assert sent == [], "the whole point of the S3 state"
+
+    def test_announces_only_the_newly_live_division(self, sent):
+        probe = _probe(
+            [
+                _result(state=ReleaseState.LIVE, count=25),
+                _result(division="Florida", state=ReleaseState.LIVE, count=12),
+            ]
+        )
+        state_in = ReleaseWatchState(seen_live=["U15 Northeast"], last_season="2026-2027")
+
+        result, state = _run(probe, state_in)
+
+        assert result.exit_code == 10
+        assert "U15 Florida" in sent[0]
+        assert "U15 Northeast" not in sent[0]
+        assert state.seen_live == ["U15 Florida", "U15 Northeast"]
+
+    def test_single_outage_is_silent(self, sent):
+        """One failed run against someone else's server is noise."""
+        probe = _probe([_result(state=ReleaseState.ERROR, error="timeout")])
+        result, state = _run(probe, ReleaseWatchState())
+
+        assert result.exit_code == 20
+        assert sent == []
+        assert state.consecutive_failures == 1
+
+    def test_sustained_outage_alerts_at_the_threshold(self, sent):
+        probe = _probe([_result(state=ReleaseState.ERROR, error="timeout")])
+        state_in = ReleaseWatchState(consecutive_failures=2, last_season="2026-2027")
+
+        result, state = _run(probe, state_in)
+
+        assert result.exit_code == 20
+        assert len(sent) == 1
+        assert "failing" in sent[0].lower()
+        assert state.failure_alert_sent is True
+
+    def test_sustained_outage_alerts_only_once(self, sent):
+        probe = _probe([_result(state=ReleaseState.ERROR, error="timeout")])
+        state_in = ReleaseWatchState(
+            consecutive_failures=5, failure_alert_sent=True, last_season="2026-2027"
+        )
+
+        result, _ = _run(probe, state_in)
+
+        assert result.exit_code == 20
+        assert sent == [], "already alerted for this streak"
+
+    def test_recovery_clears_the_failure_streak(self, sent):
+        probe = _probe([_result()])
+        state_in = ReleaseWatchState(
+            consecutive_failures=4, failure_alert_sent=True, last_season="2026-2027"
+        )
+
+        result, state = _run(probe, state_in)
+
+        assert result.exit_code == 0
+        assert state.consecutive_failures == 0
+        assert state.failure_alert_sent is False
+
+    def test_partial_failure_is_not_an_outage(self, sent):
+        probe = _probe(
+            [_result(), _result(division="Florida", state=ReleaseState.ERROR, error="x")]
+        )
+        result, state = _run(probe, ReleaseWatchState())
+
+        assert result.exit_code == 0
+        assert sent == []
+        assert state.consecutive_failures == 0
+
+    def test_dry_run_sends_nothing_and_saves_nothing(self, sent):
+        probe = _probe([_result(state=ReleaseState.LIVE, count=25)])
+        result, state = _run(probe, ReleaseWatchState(), extra_args=["--dry-run"])
+
+        assert sent == []
+        assert state is None, "dry run must not persist"
+        assert result.exit_code == 10, "still reports what it found"
+
+    def test_unknown_division_exits_one(self):
+        result = runner.invoke(app, ["watch-release", "-d", "Atlantis"])
+        assert result.exit_code == 1


### PR DESCRIPTION
## What and why

Deployment half of **SB-499**. The detector shipped in match-scraper ([#67](https://github.com/silverbeer/match-scraper/pull/67), merged) but nothing ran it on a schedule, so SB-499's actual requirement — *"must run unattended Fri 2026-08-07 → Sun 2026-08-09"* — was not met. This closes that.

## The watcher

New `watch-release` command on a 30-minute CronJob. Probes modular11 for published fixtures across **Northeast, Florida and Mid-Atlantic** (U15 first), announces the first detection of each target on Telegram, and otherwise stays silent — "still not published" is the expected state for weeks.

**Notify-only, deliberately.** It never scrapes. A new season's page format is unverified until a human looks at it, and publishing bad data to missing-table unattended is worse than waiting a few hours.

| Exit | Meaning | Telegram |
|------|---------|----------|
| `0`  | Nothing new | silent |
| `10` | Newly published | 🎉 announcement |
| `20` | All targets failed | ⚠️ only once the streak hits the threshold (default 3) |

## Three things that would have bitten us

**State must be remote.** CronJob pods are ephemeral. A local state file would re-announce the same release every 30 minutes — the exact alert spam the watcher exists to prevent. State goes to S3, mirroring `utils/journal.py` (lazy boto3, log-and-continue rather than raise, because a watcher that dies on an S3 hiccup stops watching entirely).

**Season changes must clear memory.** Otherwise last season's announcements suppress this season's, and the watcher goes permanently quiet after its first success. Tested.

**Kubernetes reads any non-zero exit as a failed Job.** Exit 10 and 20 signal *outcomes*, not failures — left alone, k8s would retry the run and clutter the history on precisely the occasions the watcher worked correctly. The CronJob maps 10/20 back to zero; anything else still fails. The mapping was exercised against all five cases.

## Also fixed — both stale since the rollover

- **`SEASON_END = date(2026, 6, 30)`** — a date in the *past*, enforced as a floor on `end_date`, so agent defaults were producing an end before the start. **Live bug.** Now derived from the current season.
- **`_current_season()` reimplemented the August cutoff locally.** Now delegates to match-scraper. Two copies of that rule is how the agent and the scraper ended up posting different season formats (`2025-2026` vs `2024-25`) for the same match.

Bumps `mls-match-scraper` `430564f` → `1713113`.

## Testing

- **138 tests pass** (115 → 138); ruff clean
- 23 new tests, weighted toward the quiet paths: no re-announce, single outage silent, sustained outage alerts once, recovery clears the streak, partial failure is not an outage, season change clears memory, corrupt S3 state degrades to blank rather than raising
- `kubectl apply --dry-run=client` validates the manifest
- Exit-code wrapper verified for codes 0/10/20/1/7
- Ran live against the real endpoint: `2026-2027: no fixtures yet across 18 targets`

## Deploying

`k3s/deploy.sh` now applies it, or:

```bash
kubectl apply -f k3s/match-scraper-agent/configmap.yaml   # adds AGENT_RELEASE_WATCH_S3_KEY
kubectl apply -f k3s/release-watch/cronjob.yaml
```

Needs a rebuilt image to pick up the new SHA and command.

## Follow-ups, not in this PR

- The **QoP CronJob is silently dead** — returns `There are no teams.` every Friday since the rollover.
- Once fixtures land: `discover` + `enrich` for Mid-Atlantic clubs, then verify a real scrape before trusting it.

Fixes SB-538

🤖 Generated with [Claude Code](https://claude.com/claude-code)
