### PR TITLE
fix: Clamp scrape windows to the season start

### DIFF
--- a/src/agent/planner.py
+++ b/src/agent/planner.py
@@ -158,11 +158,24 @@ def fetch_mt_status(
     return targets, "ok"
 
 
+def _clamp(start: date, end: date, season_start: date) -> tuple[date, date]:
+    """
+    Confine a planned window to dates MLS Next will serve.
+
+    Mirrors ``tools.clamp_scrape_range``, applied here as well so that plans,
+    logs and Telegram reports quote the dates actually scraped rather than the
+    ones we would have liked.
+    """
+    clamped_start = max(start, season_start)
+    return clamped_start, max(end, clamped_start)
+
+
 def compute_scrape_plan(
     mt_targets: list[dict[str, Any]],
     target_configs: dict[str, dict[str, str]],
     today: date,
     season_end: date,
+    season_start: date,
 ) -> RunPlan:
     """Compute a deterministic scrape plan for all non-IFA targets.
 
@@ -171,6 +184,12 @@ def compute_scrape_plan(
         target_configs: The _TARGET_SCRAPER_CONFIG dict from main.py.
         today: Today's date.
         season_end: Season end date (SEASON_END constant).
+        season_start: Earliest date MLS Next serves (SEASON_START constant).
+            Windows are clamped to it — the score-sync window looks back to the
+            Friday before last weekend, which in early August lands in the
+            previous season and the site rejects outright. Required rather than
+            defaulted, so this planner stays a pure function of its arguments
+            instead of quietly depending on the wall clock.
     """
     # Build lookup: (age_group, league, division) → MT target data
     mt_lookup: dict[tuple[str, str, str], dict[str, Any]] = {}
@@ -188,13 +207,14 @@ def compute_scrape_plan(
         mt_data = mt_lookup.get(lookup_key)
 
         if mt_data is None or mt_data.get("total", 0) == 0:
+            full_start, full_end = _clamp(today, season_end, season_start)
             plans.append(
                 ScrapePlan(
                     target_key=target_key,
                     target_label=label,
                     action=ScrapeAction.FULL_SYNC,
-                    start_date=today,
-                    end_date=season_end,
+                    start_date=full_start,
+                    end_date=full_end,
                     reason="No matches in MT — needs initial sync",
                     scraper_params=cfg,
                 )
@@ -205,7 +225,7 @@ def compute_scrape_plan(
         needs_kickoff = mt_data.get("needs_kickoff", 0)
 
         if needs_score > 0:
-            fri, mon = _match_weekend_window(today)
+            fri, mon = _clamp(*_match_weekend_window(today), season_start)
 
             reason_parts = [f"{needs_score} match(es) awaiting scores"]
             if needs_kickoff > 0:
@@ -225,13 +245,16 @@ def compute_scrape_plan(
             continue
 
         if needs_kickoff > 0:
+            ko_start, ko_end = _clamp(
+                today, today + timedelta(days=_KICKOFF_LOOKAHEAD_DAYS), season_start
+            )
             plans.append(
                 ScrapePlan(
                     target_key=target_key,
                     target_label=label,
                     action=ScrapeAction.KICKOFF_SYNC,
-                    start_date=today,
-                    end_date=today + timedelta(days=_KICKOFF_LOOKAHEAD_DAYS),
+                    start_date=ko_start,
+                    end_date=ko_end,
                     reason=f"{needs_kickoff} match(es) missing kick-off time",
                     scraper_params=cfg,
                 )

--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -42,6 +42,34 @@ def _normalize_team_name(name: str, *, league: str = "") -> str:
 # current season means the rollover is a no-op instead of an outage.
 SEASON_END = season_window(current_season_year())[1]
 
+# Season start date — the earliest date MLS Next will serve. The schedule
+# calendar refuses to navigate to months before the current season and fails
+# with "Failed to navigate to start date month", so asking for anything
+# earlier is not a smaller result, it is a broken scrape.
+SEASON_START = season_window(current_season_year())[0]
+
+
+def clamp_scrape_range(start: date, end: date) -> tuple[date, date]:
+    """
+    Confine a scrape window to dates MLS Next will actually serve.
+
+    Two guards, both learned the hard way:
+
+    * ``start`` is raised to the season start. The weekend-scores window looks
+      back to the Friday before last weekend, which in early August points at
+      the previous season — a range the site rejects outright.
+    * ``end`` is never allowed before ``start``. The season window closes on
+      15 July while the season year rolls over on 1 August, leaving the second
+      half of July a dead zone where an unguarded ``end`` sits in the past.
+      That inversion produced ``look_back_days=-33`` and failed every
+      production run.
+
+    Returns the corrected ``(start, end)``.
+    """
+    clamped_start = max(start, SEASON_START)
+    clamped_end = max(end, clamped_start)
+    return clamped_start, clamped_end
+
 
 async def scrape_matches(
     ctx: RunContext,
@@ -61,8 +89,20 @@ async def scrape_matches(
     from src.scraper.config import ScrapingConfig
     from src.scraper.mls_scraper import MLSScraper
 
-    parsed_start = date.fromisoformat(start_date)
-    parsed_end = date.fromisoformat(end_date)
+    requested_start = date.fromisoformat(start_date)
+    requested_end = date.fromisoformat(end_date)
+
+    # Last line of defence: every scrape goes through here, whoever planned it.
+    parsed_start, parsed_end = clamp_scrape_range(requested_start, requested_end)
+    if (parsed_start, parsed_end) != (requested_start, requested_end):
+        logger.info(
+            "tool.scrape_matches.range_clamped",
+            requested_start=requested_start.isoformat(),
+            requested_end=requested_end.isoformat(),
+            start=parsed_start.isoformat(),
+            end=parsed_end.isoformat(),
+            season_start=SEASON_START.isoformat(),
+        )
 
     look_back = (parsed_end - parsed_start).days
 
@@ -81,8 +121,8 @@ async def scrape_matches(
 
     logger.info(
         "tool.scrape_matches",
-        start=start_date,
-        end=end_date,
+        start=parsed_start.isoformat(),
+        end=parsed_end.isoformat(),
         age_group=config.age_group,
         league=config.league,
         division=config.division,
@@ -145,10 +185,10 @@ async def scrape_matches(
             target += f" {config.conference}"
         elif config.division:
             target += f" {config.division}"
-        return f"No matches found for {target} ({start_date} to {end_date})."
+        return f"No matches found for {target} ({parsed_start} to {parsed_end})."
 
     # Build a human-readable summary
-    lines = [f"Found {len(matches)} matches ({start_date} to {end_date}):"]
+    lines = [f"Found {len(matches)} matches ({parsed_start} to {parsed_end}):"]
     for m in matches:
         score = f" ({m.home_score}-{m.away_score})" if m.has_score() else ""
         status = m.match_status

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -254,7 +254,7 @@ def run(
             from datetime import UTC, datetime
 
             from agent.planner import compute_scrape_plan, fetch_mt_status
-            from agent.tools import SEASON_END, _current_season
+            from agent.tools import SEASON_END, SEASON_START, _current_season
 
             now_utc = datetime.now(tz=UTC)
             mt_targets, mt_status_str = fetch_mt_status(
@@ -277,6 +277,7 @@ def run(
                 target_configs=_TARGET_SCRAPER_CONFIG,
                 today=now_utc.date(),
                 season_end=SEASON_END,
+                season_start=SEASON_START,
             )
             ctx._scrape_plan = plan
 

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -12,6 +12,9 @@ from agent.planner import (
 )
 
 SEASON_END = date(2026, 6, 30)
+# Matching season start for the 2025-2026 fixtures these tests use, so the
+# SB-546 clamp is a no-op here rather than rewriting every expected date.
+SEASON_START = date(2025, 8, 1)
 
 # Minimal target configs (mirrors _TARGET_SCRAPER_CONFIG without IFA entries)
 SAMPLE_CONFIGS = {
@@ -90,6 +93,7 @@ class TestComputeScrapePlan:
             SAMPLE_CONFIGS,
             date(2026, 3, 12),
             SEASON_END,
+            SEASON_START,
         )
 
         assert len(plan.plans) == 3  # excludes u14-hg-ifa
@@ -115,6 +119,7 @@ class TestComputeScrapePlan:
             SAMPLE_CONFIGS,
             date(2026, 3, 12),
             SEASON_END,
+            SEASON_START,
         )
 
         u14 = next(p for p in plan.plans if p.target_key == "u14-hg")
@@ -133,6 +138,7 @@ class TestComputeScrapePlan:
             SAMPLE_CONFIGS,
             date(2026, 3, 12),
             SEASON_END,
+            SEASON_START,
         )
 
         u13 = next(p for p in plan.plans if p.target_key == "u13-hg")
@@ -151,19 +157,20 @@ class TestComputeScrapePlan:
             SAMPLE_CONFIGS,
             date(2026, 3, 12),
             SEASON_END,
+            SEASON_START,
         )
 
         u14 = next(p for p in plan.plans if p.target_key == "u14-hg")
         assert u14.action == ScrapeAction.FULL_SYNC
 
     def test_empty_mt_response_full_sync_all(self):
-        plan = compute_scrape_plan([], SAMPLE_CONFIGS, date(2026, 3, 12), SEASON_END)
+        plan = compute_scrape_plan([], SAMPLE_CONFIGS, date(2026, 3, 12), SEASON_END, SEASON_START)
 
         for p in plan.plans:
             assert p.action == ScrapeAction.FULL_SYNC
 
     def test_ifa_targets_excluded(self):
-        plan = compute_scrape_plan([], SAMPLE_CONFIGS, date(2026, 3, 12), SEASON_END)
+        plan = compute_scrape_plan([], SAMPLE_CONFIGS, date(2026, 3, 12), SEASON_END, SEASON_START)
         keys = [p.target_key for p in plan.plans]
         assert "u14-hg-ifa" not in keys
 
@@ -177,6 +184,7 @@ class TestComputeScrapePlan:
             SAMPLE_CONFIGS,
             date(2026, 3, 12),
             SEASON_END,
+            SEASON_START,
         )
 
         academy = next(p for p in plan.plans if p.target_key == "u14-academy")
@@ -199,6 +207,7 @@ class TestComputeScrapePlan:
             SAMPLE_CONFIGS,
             date(2026, 3, 12),
             SEASON_END,
+            SEASON_START,
         )
 
         u14 = next(p for p in plan.plans if p.target_key == "u14-hg")
@@ -222,6 +231,7 @@ class TestComputeScrapePlan:
             SAMPLE_CONFIGS,
             today,
             SEASON_END,
+            SEASON_START,
         )
 
         u14 = next(p for p in plan.plans if p.target_key == "u14-hg")
@@ -245,6 +255,7 @@ class TestComputeScrapePlan:
             SAMPLE_CONFIGS,
             date(2026, 3, 12),
             SEASON_END,
+            SEASON_START,
         )
 
         u14 = next(p for p in plan.plans if p.target_key == "u14-hg")
@@ -269,7 +280,93 @@ class TestComputeScrapePlan:
             SAMPLE_CONFIGS,
             date(2026, 3, 12),
             SEASON_END,
+            SEASON_START,
         )
 
         u14 = next(p for p in plan.plans if p.target_key == "u14-hg")
         assert u14.action == ScrapeAction.SKIP
+
+
+class TestSeasonStartClamping:
+    """
+    MLS Next only serves dates from the season start forward (SB-546).
+
+    Asking for anything earlier is not a smaller result — the calendar widget
+    fails with "Failed to navigate to start date month" and the scrape returns
+    nothing, silently.
+    """
+
+    SEASON_START = date(2026, 8, 1)
+    SEASON_END = date(2027, 7, 15)
+
+    def _plan(self, today, mt_targets=None):
+        return compute_scrape_plan(
+            mt_targets=mt_targets if mt_targets is not None else [],
+            target_configs={
+                "u15-hg": {"age_group": "U15", "league": "Homegrown", "division": "Northeast"}
+            },
+            today=today,
+            season_end=self.SEASON_END,
+            season_start=self.SEASON_START,
+        )
+
+    def test_score_sync_window_cannot_predate_the_season(self):
+        """
+        On 2026-08-02 the raw weekend window starts 2026-07-24 — the previous
+        season. This is the case that was still broken after SB-538.
+        """
+        mt = [
+            {
+                "age_group": "U15",
+                "league": "Homegrown",
+                "division": "Northeast",
+                "total": 10,
+                "needs_score": 3,
+                "needs_kickoff": 0,
+            }
+        ]
+        plan = self._plan(date(2026, 8, 2), mt)
+        scrape = plan.plans[0]
+
+        assert scrape.start_date >= self.SEASON_START
+        assert scrape.start_date == self.SEASON_START
+
+    def test_full_sync_start_is_clamped(self):
+        plan = self._plan(date(2026, 7, 20))
+        assert plan.plans[0].start_date >= self.SEASON_START
+
+    def test_no_plan_ever_starts_before_the_season(self):
+        """Sweep the rollover boundary — no window may predate the season."""
+        for day in range(1, 32):
+            for month, year in ((7, 2026), (8, 2026)):
+                try:
+                    today = date(year, month, day)
+                except ValueError:
+                    continue
+                for mt in (
+                    [],
+                    [
+                        {
+                            "age_group": "U15",
+                            "league": "Homegrown",
+                            "division": "Northeast",
+                            "total": 10,
+                            "needs_score": 2,
+                            "needs_kickoff": 0,
+                        }
+                    ],
+                    [
+                        {
+                            "age_group": "U15",
+                            "league": "Homegrown",
+                            "division": "Northeast",
+                            "total": 10,
+                            "needs_score": 0,
+                            "needs_kickoff": 4,
+                        }
+                    ],
+                ):
+                    plan = self._plan(today, mt)
+                    for s in plan.plans:
+                        assert s.start_date >= self.SEASON_START, f"{today} {s.action}"
+                        assert s.end_date >= s.start_date, f"{today} {s.action} inverted"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from agent.deps import RunContext
@@ -172,3 +172,63 @@ class TestSubmitMatches:
         result = asyncio.run(submit_matches(ctx))
         assert "Submitted 2 matches" in result
         assert "1 errors" in result
+
+
+class TestClampScrapeRange:
+    """
+    Guards on the window handed to the scraper (SB-546).
+
+    MLS Next serves only the current season; an earlier start makes the
+    calendar widget fail rather than return less, and an inverted range makes
+    ScrapingConfig reject look_back_days outright.
+    """
+
+    def test_start_is_raised_to_the_season_start(self):
+        from agent.tools import SEASON_START, clamp_scrape_range
+
+        start, _ = clamp_scrape_range(
+            SEASON_START - timedelta(days=40), SEASON_START + timedelta(days=30)
+        )
+
+        assert start == SEASON_START
+
+    def test_start_inside_the_season_is_untouched(self):
+        from agent.tools import SEASON_START, clamp_scrape_range
+
+        wanted = SEASON_START + timedelta(days=60)
+        start, end = clamp_scrape_range(wanted, wanted + timedelta(days=7))
+
+        assert start == wanted
+        assert end == wanted + timedelta(days=7)
+
+    def test_inverted_range_is_never_returned(self):
+        """
+        The production failure: end 33 days before start produced
+        look_back_days=-33 and killed every run.
+        """
+        from agent.tools import SEASON_START, clamp_scrape_range
+
+        start, end = clamp_scrape_range(
+            SEASON_START + timedelta(days=1), SEASON_START - timedelta(days=32)
+        )
+
+        assert end >= start
+        assert (end - start).days >= 0
+
+    def test_look_back_days_is_never_negative(self):
+        """Whatever we feed it, the derived look_back must satisfy ScrapingConfig."""
+        from agent.tools import SEASON_START, clamp_scrape_range
+
+        for start_offset in (-400, -60, -1, 0, 1, 200):
+            for end_offset in (-400, -33, 0, 5, 300):
+                start, end = clamp_scrape_range(
+                    SEASON_START + timedelta(days=start_offset),
+                    SEASON_START + timedelta(days=end_offset),
+                )
+                assert start >= SEASON_START
+                assert (end - start).days >= 0
+
+    def test_season_end_is_after_season_start(self):
+        from agent.tools import SEASON_END, SEASON_START
+
+        assert SEASON_START < SEASON_END


### PR DESCRIPTION
## The problem

MLS Next now serves **only the current season** — dates from 2026-08-01 forward. The schedule calendar refuses earlier months with `Failed to navigate to start date month`, so a pre-season date doesn't return less data, it breaks the scrape.

This showed up two different ways in production:

| CronJob | Symptom | Visible? |
|---|---|---|
| `match-scraper-agent` | `look_back_days=-33`, hard failure | yes — Failed jobs |
| legacy `match-scraper-homegrown-u14` | `Failed to navigate to next page` → `Successfully found 0 matches`, **exit 0** | **no** — reports Complete |

The second is the nastier one: a CronJob showing Complete while scraping nothing.

## What SB-538 missed

SB-538 fixed `SEASON_END`, which cleared the hard failure. But `_match_weekend_window(today)` returns the Friday *before* last weekend — on 2026-08-02 that's **2026-07-31**, still the previous season. It hasn't bitten only because MT has no 2026-2027 matches needing scores yet (`score_sync: 0`); it fires the moment matches exist, and it recurs every August.

## The fix

Two guards, in the path every scrape takes:

- **`start` is raised to `SEASON_START`.**
- **`end` may never precede `start`.** `season_window()` closes 15 July while the season year rolls over 1 August, leaving the second half of July a dead zone where `end` sits in the past — the same inversion that produced `-33`.

Applied in `tools.scrape_matches` (the choke point every scrape passes through, whoever planned it) *and* in the planner, so plans, logs and Telegram reports quote the dates actually used. A clamp that changes the window is logged.

Verified against today's real dates:

```
raw weekend window   (2026-07-31, 2026-08-10)
clamped              (2026-08-01, 2026-08-10)
full_sync clamped    (2026-08-02, 2027-07-15)
```

## An API change worth noting

`compute_scrape_plan` now **requires** `season_start` instead of defaulting it. I tried defaulting to the module constant first; that made the planner's output depend on the wall clock — which defeats the point of a deterministic planner and silently rewrote the expected dates in existing tests. Callers pass it explicitly now.

## Testing

- **146 pass** (138 → 146); ruff clean
- New: the exact `-33` inversion as a regression, a sweep across every day of the July/August rollover boundary asserting no plan ever starts before the season or inverts, and a matrix over `clamp_scrape_range` confirming `look_back_days` can never come out negative
- Existing planner tests were on 2025-2026 fixtures; they now pass a matching `SEASON_START` so the clamp is correctly a no-op there rather than rewriting their expectations

## Not covered here

The legacy `match-scraper-homegrown-u14` / `match-scraper-academy-u14` CronJobs run an old `match-scraper:latest` image from neither repo's manifests. This fix does not reach them — they will keep silently finding 0 matches until they're rebuilt or removed. Open question raised separately.

Fixes SB-546

🤖 Generated with [Claude Code](https://claude.com/claude-code)
