### PR TITLE
fix: Scrape one segment at a time, not the whole season

### DIFF
--- a/src/agent/engine.py
+++ b/src/agent/engine.py
@@ -11,7 +11,7 @@ import structlog
 from agent.deps import RunContext
 from agent.planner import RunPlan, ScrapeAction, ScrapePlan
 from agent.result import AgentAction, AgentResult
-from agent.tools import SEASON_END, scrape_matches, submit_matches
+from agent.tools import current_segment_window, scrape_matches, submit_matches
 from utils.journal import RunJournal, TargetEntry
 
 logger = structlog.get_logger()
@@ -42,7 +42,9 @@ def error_retry(sp: ScrapePlan, entry: TargetEntry | None) -> ScrapePlan:
                 "action": ScrapeAction.FULL_SYNC,
                 "reason": f"Retrying after {entry.errors} error(s) last run",
                 "start_date": date.today(),
-                "end_date": SEASON_END,
+                # Segment, not season — a range ending in the season's final
+                # month cannot be set in the date picker (SB-551).
+                "end_date": current_segment_window()[1],
             }
         )
     return sp

--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import date
+from datetime import date, timedelta
 
 import structlog
-from src.scraper.modular11 import current_season_year, season_label, season_window
+from src.scraper.modular11 import (
+    current_season_year,
+    fall_segment_window,
+    season_label,
+    season_window,
+)
 
 from agent.deps import RunContext
 
@@ -48,6 +53,49 @@ SEASON_END = season_window(current_season_year())[1]
 # earlier is not a smaller result, it is a broken scrape.
 SEASON_START = season_window(current_season_year())[0]
 
+# The latest date a scrape may end on.
+#
+# The MLS Next date picker shows two month panels side by side, and the
+# season's final month (July 2027) is the last one it will render — there is
+# no August 2027 to pair it with, so July can only ever be the *right* panel.
+# Our calendar code navigates the start month into the *left* panel, so any
+# range ending in that final month fails with "Failed to navigate to start
+# date month". Measured 2026-08-03: a range ending 15 Jun 2027 works, one
+# ending 15 Jul 2027 fails, and even a two-week range inside July 2027 fails.
+#
+# So we stop at the end of the month *before* the season's final month.
+#
+# This costs no data: matches run September-November in the fall segment and
+# March-June in the spring, so nothing is ever scheduled in the season's first
+# or last month.
+SCRAPE_END_CAP = SEASON_END.replace(day=1) - timedelta(days=1)
+
+
+def current_segment_window(today: date | None = None) -> tuple[date, date]:
+    """
+    Return the window for the segment ``today`` falls in.
+
+    The season splits in two, and scraping a segment at a time keeps the
+    request inside what the date picker can express:
+
+    * Fall:   1 August  - 31 December
+    * Spring: 1 January - 1 July
+
+    The returned end is capped at :data:`SCRAPE_END_CAP`, so the spring
+    segment stops short of the season's unreachable final month rather than
+    reproducing the full_sync failure every January.
+    """
+    today = today or date.today()
+    season_year = current_season_year(today)
+    fall_start, fall_end = fall_segment_window(season_year)
+
+    if today <= fall_end:
+        return fall_start, min(fall_end, SCRAPE_END_CAP)
+
+    spring_start = date(season_year + 1, 1, 1)
+    spring_end = date(season_year + 1, 7, 1)
+    return spring_start, min(spring_end, SCRAPE_END_CAP)
+
 
 def clamp_scrape_range(start: date, end: date) -> tuple[date, date]:
     """
@@ -58,6 +106,9 @@ def clamp_scrape_range(start: date, end: date) -> tuple[date, date]:
     * ``start`` is raised to the season start. The weekend-scores window looks
       back to the Friday before last weekend, which in early August points at
       the previous season — a range the site rejects outright.
+    * ``end`` is lowered to :data:`SCRAPE_END_CAP`, keeping the range clear of
+      the season's final month, which the date picker cannot use as the left
+      panel.
     * ``end`` is never allowed before ``start``. The season window closes on
       15 July while the season year rolls over on 1 August, leaving the second
       half of July a dead zone where an unguarded ``end`` sits in the past.
@@ -67,7 +118,7 @@ def clamp_scrape_range(start: date, end: date) -> tuple[date, date]:
     Returns the corrected ``(start, end)``.
     """
     clamped_start = max(start, SEASON_START)
-    clamped_end = max(end, clamped_start)
+    clamped_end = max(min(end, SCRAPE_END_CAP), clamped_start)
     return clamped_start, clamped_end
 
 

--- a/src/audit/runner.py
+++ b/src/audit/runner.py
@@ -80,15 +80,23 @@ async def run_one_team_audit(
 
     # Step 2: Build ScrapingConfig — map MT canonical name back to MLS Next display name
     mls_club_name = MT_NAME_TO_MLS_NAME.get(team, team)
+
+    # This path builds ScrapingConfig directly, so it needs its own clamp:
+    # MLS Next serves only the current season and cannot express a range
+    # ending in the season's final month (SB-551).
+    from agent.tools import clamp_scrape_range
+
+    scrape_start, scrape_end = clamp_scrape_range(season_start, season_end)
+
     config = ScrapingConfig(
         age_group=age_group,
         league=league,
         division=division,
         conference="",
         club=mls_club_name,
-        start_date=season_start,
-        end_date=season_end,
-        look_back_days=(season_end - season_start).days,
+        start_date=scrape_start,
+        end_date=scrape_end,
+        look_back_days=(scrape_end - scrape_start).days,
         missing_table_api_url=settings.missing_table_api_url,
         missing_table_api_key=settings.missing_table_api_key or "unused",
     )

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -229,7 +229,7 @@ def run(
             from datetime import date
 
             from agent.planner import RunPlan, ScrapeAction, ScrapePlan
-            from agent.tools import SEASON_END
+            from agent.tools import current_segment_window
 
             target_cfg = _TARGET_SCRAPER_CONFIG[target]
             label = _target_label(target_cfg)
@@ -240,7 +240,7 @@ def run(
                         target_label=label,
                         action=ScrapeAction.FULL_SYNC,
                         start_date=date.today(),
-                        end_date=SEASON_END,
+                        end_date=current_segment_window()[1],
                         reason="Targeted run",
                         scraper_params=target_cfg,
                     )
@@ -254,7 +254,7 @@ def run(
             from datetime import UTC, datetime
 
             from agent.planner import compute_scrape_plan, fetch_mt_status
-            from agent.tools import SEASON_END, SEASON_START, _current_season
+            from agent.tools import SEASON_START, _current_season, current_segment_window
 
             now_utc = datetime.now(tz=UTC)
             mt_targets, mt_status_str = fetch_mt_status(
@@ -272,11 +272,16 @@ def run(
                 )
                 raise typer.Exit(code=1)
 
+            # Scrape the current segment, not the whole remaining season: a
+            # range ending in the season's final month cannot be expressed in
+            # the MLS Next date picker and fails every full_sync (SB-551).
+            _, segment_end = current_segment_window(now_utc.date())
+
             plan = compute_scrape_plan(
                 mt_targets=mt_targets,
                 target_configs=_TARGET_SCRAPER_CONFIG,
                 today=now_utc.date(),
-                season_end=SEASON_END,
+                season_end=segment_end,
                 season_start=SEASON_START,
             )
             ctx._scrape_plan = plan
@@ -423,9 +428,10 @@ def scrape(
     from src.scraper.mls_scraper import MLSScraper
 
     from agent.tools import (
-        SEASON_END,
         _current_season,
         _normalize_team_name,
+        clamp_scrape_range,
+        current_segment_window,
     )
     from config.settings import AgentSettings, env_file_path
     from utils.logger import configure_logging
@@ -443,10 +449,20 @@ def scrape(
 
     try:
         start = date.fromisoformat(from_date) if from_date else date.today()
-        end = date.fromisoformat(to_date) if to_date else SEASON_END
+        end = date.fromisoformat(to_date) if to_date else current_segment_window()[1]
     except ValueError as exc:
         typer.echo(f"Invalid date format: {exc}. Use YYYY-MM-DD.", err=True)
         raise typer.Exit(code=1) from None
+
+    # This path builds ScrapingConfig directly rather than going through
+    # tools.scrape_matches, so it needs its own clamp.
+    requested = (start, end)
+    start, end = clamp_scrape_range(start, end)
+    if (start, end) != requested:
+        typer.echo(
+            f"Adjusted date range {requested[0]}..{requested[1]} -> {start}..{end} "
+            "(MLS Next only serves the current season, and not its final month)."
+        )
 
     config = ScrapingConfig(
         age_group=target_cfg.get("age_group", settings.age_group),

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from agent.deps import RunContext
@@ -232,3 +232,77 @@ class TestClampScrapeRange:
         from agent.tools import SEASON_END, SEASON_START
 
         assert SEASON_START < SEASON_END
+
+
+class TestCurrentSegmentWindow:
+    """
+    Scrape one segment at a time (SB-551).
+
+    A range ending in the season's final month cannot be set in the MLS Next
+    date picker: July 2027 is the last month it renders, so it can only ever
+    be the right-hand panel, and the start month is navigated into the left.
+    Measured 2026-08-03 — a range ending 15 Jun 2027 works, one ending 15 Jul
+    2027 fails, and so does a two-week range wholly inside July 2027.
+    """
+
+    def test_august_is_in_the_fall_segment(self):
+        from agent.tools import current_segment_window
+
+        start, end = current_segment_window(date(2026, 8, 3))
+
+        assert start == date(2026, 8, 1)
+        assert end == date(2026, 12, 31)
+
+    def test_november_is_still_the_fall_segment(self):
+        from agent.tools import current_segment_window
+
+        start, end = current_segment_window(date(2026, 11, 20))
+
+        assert start == date(2026, 8, 1)
+        assert end == date(2026, 12, 31)
+
+    def test_january_switches_to_the_spring_segment(self):
+        from agent.tools import current_segment_window
+
+        start, end = current_segment_window(date(2027, 1, 15))
+
+        assert start == date(2027, 1, 1)
+        assert end > start
+
+    def test_spring_segment_stops_short_of_the_unreachable_month(self):
+        """
+        The spring segment nominally runs to 1 July, but July is the season's
+        final month and unusable, so the scrape window must stop before it.
+        """
+        from agent.tools import SEASON_END, current_segment_window
+
+        _, end = current_segment_window(date(2027, 3, 1))
+
+        assert end < date(2027, 7, 1)
+        assert end.month != SEASON_END.month
+
+    def test_no_segment_window_ever_reaches_the_final_month(self):
+        from agent.tools import SEASON_END, current_segment_window
+
+        for month in range(1, 13):
+            year = 2026 if month >= 8 else 2027
+            _, end = current_segment_window(date(year, month, 15))
+            assert not (end.year == SEASON_END.year and end.month == SEASON_END.month)
+
+    def test_segment_windows_are_never_inverted(self):
+        from agent.tools import current_segment_window
+
+        for month in range(1, 13):
+            year = 2026 if month >= 8 else 2027
+            start, end = current_segment_window(date(year, month, 15))
+            assert end >= start, f"{year}-{month}"
+
+    def test_clamp_lowers_an_end_in_the_final_month(self):
+        """The production range 2026-08-03 -> 2027-07-15 that failed."""
+        from agent.tools import SEASON_END, clamp_scrape_range
+
+        start, end = clamp_scrape_range(date(2026, 8, 3), date(2027, 7, 15))
+
+        assert end < SEASON_END
+        assert end.month != SEASON_END.month
+        assert end >= start


### PR DESCRIPTION
## The bug

`full_sync` asked for `today → SEASON_END` (2027-07-15). That range **cannot be set**, so every full-sync target failed and nothing was scraped. Confirmed by triggering a real production run after SB-546 had already produced a valid window:

```
Failed to navigate to start date month   [target_month=8 target_year=2026]
```

## Root cause

The date picker renders two month panels side by side, and **July 2027 is the last month it will show** — 16–31 July are struck out, and there is no forward arrow. So July can only ever be the *right* panel; there is no August 2027 to pair with it. Our calendar code navigates the start month into the *left* panel, which can never reach July.

Measured against the live site on 2026-08-03:

| Range | Result |
|-------|--------|
| Aug 2026 → Jun 15 2027 (10 months) | ok |
| Aug 2026 → Jul 15 2027 (11 months) | **fail** |
| Jul 1 → Jul 15 2027 (two weeks) | **fail** |
| Jun 1 → Jun 15 2027 (two weeks) | ok |

Neither the span nor the start month — **any range ending in the season's final month fails**. I chased both wrong hypotheses before the two-week test isolated it.

## The fix

Scrape the current segment rather than the whole remaining season:

| Segment | Window | Matches actually played |
|---------|--------|------------------------|
| Fall | 1 Aug – 31 Dec | Sep–Nov |
| Spring | 1 Jan – 1 Jul, capped at 30 Jun | Mar–Jun |

`SEASON_END` stays 2027-07-15 — it is the correct season boundary and is still what MT is told. Only the *scrape window* changes.

**The cap costs no data.** Matches run September–November and March–June, so nothing is ever scheduled in the season's first or last month.

## Coverage of the guard

`clamp_scrape_range` now lowers an over-long end as well as raising an early start, so it holds wherever a range is built. Three paths construct `ScrapingConfig` directly and bypass `tools.scrape_matches`; each now clamps explicitly:

- the targeted `scrape` CLI command
- `engine.error_retry`
- the **audit runner** — which was doubly broken, since its default `audit_season_start` of `2026-02-01` is last season

## Verification

- **153 tests pass** (146 → 153); ruff clean
- New tests pin the exact failing production range, assert no segment window ever reaches the season's final month, and sweep all twelve months for inverted windows
- **Live check against the real site**: the new fall-segment range (`2026-08-03 → 2026-12-31`) scrapes clean — exit 0, zero navigation failures

Resulting windows:

```
2026-08-03  ->  2026-12-31     2027-03-01  ->  2027-06-30
2026-10-01  ->  2026-12-31     2027-06-20  ->  2027-06-30
```

## Follow-up

The modular11 `get_matches` HTTP endpoint returns a whole season in one GET with no calendar involved — it is already what the release watcher uses. Moving the scraper onto it deletes this entire class of bug, along with the pagination timeouts visible in the same logs.

Fixes SB-551

🤖 Generated with [Claude Code](https://claude.com/claude-code)
