### PR TITLE
feat: Persist release-watch state on the PVC when S3 is absent

### DIFF
--- a/k3s/release-watch/cronjob.yaml
+++ b/k3s/release-watch/cronjob.yaml
@@ -49,6 +49,14 @@ spec:
                     name: match-scraper-agent-config
                 - secretRef:
                     name: match-scraper-agent-secret
+              volumeMounts:
+                # "Have we already announced this?" has to outlive the pod, or
+                # the watcher re-announces every 30 minutes. The cluster has no
+                # S3 bucket and no AWS credentials in the Secret, so state goes
+                # to the same PVC the agent CronJob already uses. Setting
+                # AGENT_JOURNAL_S3_BUCKET switches it back to S3.
+                - name: agent-state
+                  mountPath: /data/agent-state
               resources:
                 # No browser — plain HTTP, so this is far lighter than the
                 # scraper CronJobs.
@@ -58,3 +66,10 @@ spec:
                 limits:
                   cpu: "250m"
                   memory: 512Mi
+          volumes:
+            # RWO, and the agent CronJob mounts it too — but the agent runs at
+            # 02/08/14/20 for a few minutes and both land on the same node, so
+            # they do not contend in practice.
+            - name: agent-state
+              persistentVolumeClaim:
+                claimName: agent-state

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -936,15 +936,15 @@ def watch_release(
 
     probe = asyncio.run(detector.probe())
 
+    # S3 when a bucket is configured, otherwise a file on the mounted PVC.
+    # Either way the state must survive the pod, or every run re-announces.
     bucket = settings.journal_s3_bucket
-    if bucket and not dry_run:
-        state = read_state(bucket, settings.release_watch_s3_key)
+    state_path = settings.release_watch_state_path
+    persist = bool(bucket or state_path) and not dry_run
+
+    if persist:
+        state = read_state(bucket, settings.release_watch_s3_key, state_path)
     else:
-        if not bucket:
-            logger.warning(
-                "release_watch.no_bucket",
-                detail="AGENT_JOURNAL_S3_BUCKET unset — every run will re-announce",
-            )
         from utils.release_watch import ReleaseWatchState
 
         state = ReleaseWatchState()
@@ -1000,8 +1000,8 @@ def watch_release(
 
     state.touch()
 
-    if bucket and not dry_run:
-        write_state(bucket, settings.release_watch_s3_key, state)
+    if persist:
+        write_state(bucket, settings.release_watch_s3_key, state, state_path)
 
     if probe.all_failed:
         raise typer.Exit(code=20)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -51,10 +51,14 @@ class AgentSettings(BaseSettings):
     journal_s3_bucket: str = ""
     journal_s3_key: str = "journal/latest.json"
 
-    # Schedule release watcher — shares the journal bucket. State must be
-    # remote because CronJob pods are ephemeral and local state would make
-    # the watcher re-announce a release on every single run.
+    # Schedule release watcher — shares the journal bucket. State must outlive
+    # the pod because CronJob pods are ephemeral, and state that does not
+    # survive would make the watcher re-announce a release on every single run.
     release_watch_s3_key: str = "release-watch/state.json"
+    # Used when no journal bucket is configured. The cluster has no bucket and
+    # no AWS credentials, so this is the deployed path — it points into the
+    # agent-state PVC, mounted by the release-watch CronJob at /data/agent-state.
+    release_watch_state_path: str = "/data/agent-state/release-watch.json"
     # Consecutive all-targets-failed runs before alerting. One failed run
     # against someone else's server is noise, not news.
     release_watch_failure_threshold: int = 3

--- a/src/utils/release_watch.py
+++ b/src/utils/release_watch.py
@@ -2,18 +2,26 @@
 Cross-run state for the schedule release watcher.
 
 CronJob pods are ephemeral, so "have we already announced this?" cannot live
-on local disk — a fresh pod would re-announce on every run, which is exactly
-the alert spam the watcher exists to avoid. State goes to S3 alongside the run
-journal.
+in the container filesystem — a fresh pod would re-announce on every run,
+which is exactly the alert spam the watcher exists to avoid.
+
+Two backends, chosen by whether an S3 bucket is configured:
+
+* ``AGENT_JOURNAL_S3_BUCKET`` set → S3, alongside the run journal.
+* otherwise → a JSON file at ``AGENT_RELEASE_WATCH_STATE_PATH``, which on the
+  cluster points into the ``agent-state`` PVC. The live cluster has no bucket
+  and no AWS credentials, so this is the deployed path; setting the bucket env
+  var switches back to S3 with no code change.
 
 Mirrors ``utils.journal``: lazy boto3 import, and reads/writes that log and
-carry on rather than raising. A watcher that dies because S3 hiccuped is worse
-than one that sends a duplicate message.
+carry on rather than raising. A watcher that dies because its store hiccuped
+is worse than one that sends a duplicate message.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from pathlib import Path
 
 import structlog
 from pydantic import BaseModel, Field
@@ -74,13 +82,16 @@ class ReleaseWatchState(BaseModel):
         self.last_probe_at = (now or datetime.now(tz=UTC)).isoformat()
 
 
-def read_state(bucket: str, key: str) -> ReleaseWatchState:
+def read_state(bucket: str, key: str, local_path: str = "") -> ReleaseWatchState:
     """
-    Read watch state from S3.
+    Read watch state from S3, or from ``local_path`` when no bucket is set.
 
     Returns a blank state when the object is missing or unreadable — the
     watcher should start announcing again rather than refuse to run.
     """
+    if not bucket:
+        return _read_local(local_path)
+
     import boto3
     from botocore.exceptions import ClientError
 
@@ -98,8 +109,12 @@ def read_state(bucket: str, key: str) -> ReleaseWatchState:
         return ReleaseWatchState()
 
 
-def write_state(bucket: str, key: str, state: ReleaseWatchState) -> None:
-    """Write watch state to S3. Never raises."""
+def write_state(bucket: str, key: str, state: ReleaseWatchState, local_path: str = "") -> None:
+    """Write watch state to S3, or to ``local_path`` when no bucket is set. Never raises."""
+    if not bucket:
+        _write_local(local_path, state)
+        return
+
     import boto3
 
     try:
@@ -113,3 +128,44 @@ def write_state(bucket: str, key: str, state: ReleaseWatchState) -> None:
         logger.info("release_watch.written", bucket=bucket, key=key)
     except Exception as exc:
         logger.warning("release_watch.write_failed", bucket=bucket, key=key, error=str(exc))
+
+
+def _read_local(path: str) -> ReleaseWatchState:
+    """Read watch state from a JSON file, blank if absent or unreadable."""
+    if not path:
+        logger.warning(
+            "release_watch.no_state_store",
+            detail="no S3 bucket and no state path — every run will re-announce",
+        )
+        return ReleaseWatchState()
+
+    try:
+        return ReleaseWatchState.model_validate_json(Path(path).read_text())
+    except FileNotFoundError:
+        logger.debug("release_watch.read_skipped", path=path, reason="not found")
+        return ReleaseWatchState()
+    except Exception as exc:
+        logger.debug("release_watch.read_skipped", path=path, reason=str(exc))
+        return ReleaseWatchState()
+
+
+def _write_local(path: str, state: ReleaseWatchState) -> None:
+    """
+    Write watch state to a JSON file. Never raises.
+
+    Writes to a sibling temp file and renames, so a pod killed mid-write leaves
+    the previous state intact rather than a truncated file that parses as blank
+    and re-announces.
+    """
+    if not path:
+        return
+
+    try:
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_name(f"{target.name}.tmp")
+        tmp.write_text(state.model_dump_json(indent=2))
+        tmp.replace(target)
+        logger.info("release_watch.written", path=path)
+    except Exception as exc:
+        logger.warning("release_watch.write_failed", path=path, error=str(exc))

--- a/tests/test_release_watch.py
+++ b/tests/test_release_watch.py
@@ -147,6 +147,68 @@ class TestS3State:
 
 
 # ---------------------------------------------------------------------------
+# Local file round trip — the backend actually deployed on the cluster, which
+# has no bucket and no AWS credentials.
+# ---------------------------------------------------------------------------
+
+
+class TestLocalFileState:
+    def test_round_trip(self, tmp_path):
+        path = str(tmp_path / "release-watch.json")
+        write_state("", KEY, ReleaseWatchState(seen_live=["U15 Northeast"]), path)
+
+        restored = read_state("", KEY, path)
+        assert restored.seen_live == ["U15 Northeast"]
+
+    def test_missing_file_yields_blank_state(self, tmp_path):
+        assert read_state("", KEY, str(tmp_path / "absent.json")).seen_live == []
+
+    def test_unreadable_state_yields_blank_rather_than_raising(self, tmp_path):
+        path = tmp_path / "release-watch.json"
+        path.write_text("not json")
+        assert read_state("", KEY, str(path)).seen_live == []
+
+    def test_parent_directory_is_created(self, tmp_path):
+        path = str(tmp_path / "nested" / "dir" / "release-watch.json")
+        write_state("", KEY, ReleaseWatchState(seen_live=["U15 Florida"]), path)
+        assert read_state("", KEY, path).seen_live == ["U15 Florida"]
+
+    def test_write_failure_never_raises(self, tmp_path):
+        """A directory where the file should be — write fails, watcher lives."""
+        path = tmp_path / "release-watch.json"
+        path.mkdir()
+        write_state("", KEY, ReleaseWatchState(), str(path))  # must not raise
+
+    def test_a_failed_write_leaves_the_previous_state_intact(self, tmp_path):
+        """Truncated state parses as blank, which would re-announce."""
+        path = tmp_path / "release-watch.json"
+        write_state("", KEY, ReleaseWatchState(seen_live=["U15 Northeast"]), str(path))
+
+        with patch("pathlib.Path.replace", side_effect=OSError("disk full")):
+            write_state("", KEY, ReleaseWatchState(seen_live=["U15 Florida"]), str(path))
+
+        assert read_state("", KEY, str(path)).seen_live == ["U15 Northeast"]
+
+    def test_no_bucket_and_no_path_is_blank_not_a_crash(self):
+        assert read_state("", KEY, "").seen_live == []
+        write_state("", KEY, ReleaseWatchState(), "")  # must not raise
+
+    def test_a_configured_bucket_still_wins(self, tmp_path):
+        """One env var flips back to S3 — the local path is not consulted."""
+        path = tmp_path / "release-watch.json"
+        path.write_text(ReleaseWatchState(seen_live=["stale local"]).model_dump_json())
+
+        s3 = MagicMock()
+        s3.get_object.return_value = {
+            "Body": MagicMock(
+                read=lambda: ReleaseWatchState(seen_live=["from s3"]).model_dump_json()
+            )
+        }
+        with patch("boto3.client", return_value=s3):
+            assert read_state(BUCKET, KEY, str(path)).seen_live == ["from s3"]
+
+
+# ---------------------------------------------------------------------------
 # The command
 # ---------------------------------------------------------------------------
 
@@ -174,7 +236,7 @@ def _run(probe, state, sent_bucket="bucket", extra_args=()):
         patch("utils.release_watch.read_state", return_value=state),
         patch(
             "utils.release_watch.write_state",
-            side_effect=lambda b, k, s: saved.update({"state": s}),
+            side_effect=lambda b, k, s, p="": saved.update({"state": s, "bucket": b, "path": p}),
         ),
         # AgentSettings reads AGENT_-prefixed env vars; the field itself is a
         # pydantic-settings descriptor and cannot be patched as an attribute.
@@ -265,6 +327,52 @@ class TestWatchReleaseCommand:
 
         assert result.exit_code == 20
         assert sent == [], "already alerted for this streak"
+
+    def test_state_survives_between_runs_on_the_local_backend(self, sent, tmp_path):
+        """
+        The deployed shape: no bucket, state on the PVC. Two runs against the
+        same published probe must announce exactly once — this is the whole
+        reason the CronJob mounts a volume.
+        """
+        probe_patch = patch(
+            "src.scraper.release_detector.ScheduleReleaseDetector.probe",
+            new=MagicMock(
+                side_effect=lambda: _async(_probe([_result(state=ReleaseState.LIVE, count=25)]))
+            ),
+        )
+        env = {
+            "AGENT_JOURNAL_S3_BUCKET": "",
+            "AGENT_RELEASE_WATCH_STATE_PATH": str(tmp_path / "release-watch.json"),
+        }
+
+        with probe_patch, patch.dict("os.environ", env):
+            first = runner.invoke(app, ["watch-release"])
+            second = runner.invoke(app, ["watch-release"])
+
+        assert first.exit_code == 10
+        assert second.exit_code == 0, "a remembered release is not news"
+        assert len(sent) == 1
+
+    def test_dry_run_writes_no_state(self, sent, tmp_path):
+        """Otherwise a dry run would silence the real announcement."""
+        state_file = tmp_path / "release-watch.json"
+        probe_patch = patch(
+            "src.scraper.release_detector.ScheduleReleaseDetector.probe",
+            new=MagicMock(
+                return_value=_async(_probe([_result(state=ReleaseState.LIVE, count=25)]))
+            ),
+        )
+        env = {
+            "AGENT_JOURNAL_S3_BUCKET": "",
+            "AGENT_RELEASE_WATCH_STATE_PATH": str(state_file),
+        }
+
+        with probe_patch, patch.dict("os.environ", env):
+            result = runner.invoke(app, ["watch-release", "--dry-run"])
+
+        assert result.exit_code == 10
+        assert sent == []
+        assert not state_file.exists()
 
     def test_recovery_clears_the_failure_streak(self, sent):
         probe = _probe([_result()])


### PR DESCRIPTION
## Why

`k3s/release-watch/cronjob.yaml` has been merged since SB-538 but never applied, so nothing polls for the MLS Next 2026-2027 schedule release. It could not be applied: the watcher persists "which targets have I already announced?" to S3 via `AGENT_JOURNAL_S3_BUCKET`, and the live cluster has no such bucket and no AWS credentials in `match-scraper-agent-secret`. With no store, every 30-minute pod starts blank and re-announces — the exact alert spam the watcher exists to prevent.

## What

* `read_state` / `write_state` dispatch on the bucket. Set → S3, unchanged. Unset → a JSON file at `AGENT_RELEASE_WATCH_STATE_PATH`, default `/data/agent-state/release-watch.json`. Flipping one env var switches back to S3 with no code change.
* The local write goes to a sibling temp file and renames. A pod killed mid-write leaves the previous state intact; a truncated file would parse as blank and re-announce.
* The CronJob mounts the `agent-state` PVC (64Mi, `local-path`, already bound, already mounted by the agent CronJob at the same path).
* No ConfigMap change needed — the default path matches the mount, so `k3s/deploy.sh` stays untouched. (It must not be run: its ConfigMap disagrees with the live cluster on the RabbitMQ hostname and omits `AGENT_PROXY_*` / `AGENT_MODEL_NAME`.)

## Tests

163 pass. New coverage for the local backend: round trip, missing file, corrupt file, parent-directory creation, write failure, and that a failed write preserves prior state. Two command-level tests cover the deployed shape end to end — two consecutive runs against the same published probe announce exactly once, and `--dry-run` writes no state.

## Deploy

CI publishes `:latest` on merge; the CronJob is `imagePullPolicy: Always`. After merge, apply **only** `k3s/release-watch/cronjob.yaml` to `rancher-desktop` / `match-scraper` and verify with `kubectl create job --from=cronjob/schedule-release-watch`. Expected steady state until MLS Next publishes: exit 0, no Telegram, `2026-2027: no fixtures yet across 18 targets`.

Fixes SB-554

🤖 Generated with [Claude Code](https://claude.com/claude-code)
