### PR TITLE
fix: Persist the run journal on the PVC when S3 is absent

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -294,12 +294,18 @@ def run(
                 skip=sum(1 for p in plan.plans if p.action.value == "skip"),
             )
 
-            # Read previous journal for modifier rules
+            # Read previous journal for modifier rules. S3 when a bucket is
+            # configured, otherwise a file on the mounted PVC — with neither,
+            # the modifier rules are dead and a failed target never retries.
             journal = None
-            if settings.journal_s3_bucket:
+            if settings.journal_s3_bucket or settings.journal_path:
                 from utils.journal import read_journal
 
-                journal = read_journal(settings.journal_s3_bucket, settings.journal_s3_key)
+                journal = read_journal(
+                    settings.journal_s3_bucket,
+                    settings.journal_s3_key,
+                    settings.journal_path,
+                )
                 if journal:
                     logger.info("journal.loaded", run_id=journal.run_id)
 
@@ -330,8 +336,10 @@ def run(
             prefix = "[DRY RUN] " if action.dry_run else ""
             typer.echo(f"  {prefix}{action.action}: {action.detail}")
 
-    # Write run journal for next run's context
-    if settings.journal_s3_bucket:
+    # Write run journal for next run's context. A dry run does not write: its
+    # journal would claim work it never did, and the next real run would skip
+    # targets on the strength of it.
+    if (settings.journal_s3_bucket or settings.journal_path) and not settings.dry_run:
         from utils.journal import build_journal, write_journal
 
         journal_out = build_journal(
@@ -342,7 +350,12 @@ def run(
             target=target,
             dry_run=settings.dry_run,
         )
-        write_journal(settings.journal_s3_bucket, settings.journal_s3_key, journal_out)
+        write_journal(
+            settings.journal_s3_bucket,
+            settings.journal_s3_key,
+            journal_out,
+            settings.journal_path,
+        )
 
     # Send Telegram summary report
     _send_telegram_report(

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -47,9 +47,13 @@ class AgentSettings(BaseSettings):
     json_logs: bool = False
     log_level: str = "info"
 
-    # Run journal (cross-run memory) — stored in S3
+    # Run journal (cross-run memory) — S3 when a bucket is set, otherwise a
+    # file. The cluster has no bucket and no AWS credentials, so the path is
+    # the deployed backend; it points into the agent-state PVC that the agent
+    # CronJob already mounts at /data/agent-state.
     journal_s3_bucket: str = ""
     journal_s3_key: str = "journal/latest.json"
+    journal_path: str = "/data/agent-state/journal.json"
 
     # Schedule release watcher — shares the journal bucket. State must outlive
     # the pod because CronJob pods are ephemeral, and state that does not

--- a/src/utils/journal.py
+++ b/src/utils/journal.py
@@ -1,8 +1,23 @@
-"""Run journal — lightweight cross-run memory for the agent."""
+"""
+Run journal — lightweight cross-run memory for the agent.
+
+Two backends, chosen by whether an S3 bucket is configured:
+
+* ``AGENT_JOURNAL_S3_BUCKET`` set → S3.
+* otherwise → a JSON file at ``AGENT_JOURNAL_PATH``, which on the cluster
+  points into the ``agent-state`` PVC the CronJob already mounts. The live
+  cluster has no bucket and no AWS credentials, so this is the deployed path;
+  setting the bucket env var switches back to S3 with no code change.
+
+Same arrangement as ``utils.release_watch``. Reads and writes log and carry on
+rather than raising: a run that dies because its journal store hiccuped is
+worse than one that plans without memory of the last run.
+"""
 
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import Any
 
 import structlog
@@ -38,8 +53,14 @@ class RunJournal(BaseModel):
     missing_score_matches: list[str] = []
 
 
-def read_journal(bucket: str, key: str) -> RunJournal | None:
-    """Read the last run journal from S3. Returns None if missing or invalid."""
+def read_journal(bucket: str, key: str, local_path: str = "") -> RunJournal | None:
+    """
+    Read the last run journal from S3, or from ``local_path`` when no bucket
+    is set. Returns None if missing or invalid.
+    """
+    if not bucket:
+        return _read_local(local_path)
+
     import boto3
     from botocore.exceptions import ClientError
 
@@ -58,8 +79,15 @@ def read_journal(bucket: str, key: str) -> RunJournal | None:
         return None
 
 
-def write_journal(bucket: str, key: str, journal: RunJournal) -> None:
-    """Write the run journal to S3. Never raises."""
+def write_journal(bucket: str, key: str, journal: RunJournal, local_path: str = "") -> None:
+    """
+    Write the run journal to S3, or to ``local_path`` when no bucket is set.
+    Never raises.
+    """
+    if not bucket:
+        _write_local(local_path, journal)
+        return
+
     import boto3
 
     try:
@@ -73,6 +101,47 @@ def write_journal(bucket: str, key: str, journal: RunJournal) -> None:
         logger.info("journal.written", bucket=bucket, key=key)
     except Exception as exc:
         logger.warning("journal.write_failed", bucket=bucket, key=key, error=str(exc))
+
+
+def _read_local(path: str) -> RunJournal | None:
+    """Read the journal from a JSON file. None if absent or unreadable."""
+    if not path:
+        logger.warning(
+            "journal.no_store",
+            detail="no S3 bucket and no journal path — this run has no memory of the last",
+        )
+        return None
+
+    try:
+        return RunJournal.model_validate_json(Path(path).read_text())
+    except FileNotFoundError:
+        logger.debug("journal.read_skipped", path=path, reason="not found")
+        return None
+    except Exception as exc:
+        logger.debug("journal.read_skipped", path=path, reason=str(exc))
+        return None
+
+
+def _write_local(path: str, journal: RunJournal) -> None:
+    """
+    Write the journal to a JSON file. Never raises.
+
+    Writes to a sibling temp file and renames, so a pod killed mid-write leaves
+    the previous journal intact rather than a truncated file that reads as no
+    memory at all.
+    """
+    if not path:
+        return
+
+    try:
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_name(f"{target.name}.tmp")
+        tmp.write_text(journal.model_dump_json(indent=2))
+        tmp.replace(target)
+        logger.info("journal.written", path=path)
+    except Exception as exc:
+        logger.warning("journal.write_failed", path=path, error=str(exc))
 
 
 def build_journal(

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -166,6 +166,66 @@ class TestWriteJournal:
             write_journal(BUCKET, KEY, journal)  # must not raise
 
 
+class TestLocalFileJournal:
+    """The backend deployed on the cluster, which has no bucket and no AWS credentials."""
+
+    def test_round_trip(self, tmp_path) -> None:
+        path = str(tmp_path / "journal.json")
+        write_journal(
+            "", KEY, RunJournal(timestamp="2026-03-09T14:00:00+00:00", run_id="xyz"), path
+        )
+
+        restored = read_journal("", KEY, path)
+        assert restored is not None
+        assert restored.run_id == "xyz"
+
+    def test_missing_file_returns_none(self, tmp_path) -> None:
+        assert read_journal("", KEY, str(tmp_path / "absent.json")) is None
+
+    def test_invalid_json_returns_none(self, tmp_path) -> None:
+        path = tmp_path / "journal.json"
+        path.write_text("not json at all")
+        assert read_journal("", KEY, str(path)) is None
+
+    def test_parent_directory_is_created(self, tmp_path) -> None:
+        path = str(tmp_path / "nested" / "dir" / "journal.json")
+        write_journal(
+            "", KEY, RunJournal(timestamp="2026-03-09T14:00:00+00:00", run_id="deep"), path
+        )
+        assert read_journal("", KEY, path).run_id == "deep"
+
+    def test_write_failure_does_not_raise(self, tmp_path) -> None:
+        path = tmp_path / "journal.json"
+        path.mkdir()  # a directory where the file should be
+        write_journal("", KEY, RunJournal(timestamp="t", run_id="x"), str(path))  # must not raise
+
+    def test_failed_write_leaves_the_previous_journal_intact(self, tmp_path) -> None:
+        """A truncated journal reads as no memory, which disables the modifier rules."""
+        path = tmp_path / "journal.json"
+        write_journal("", KEY, RunJournal(timestamp="t", run_id="first"), str(path))
+
+        with patch("pathlib.Path.replace", side_effect=OSError("disk full")):
+            write_journal("", KEY, RunJournal(timestamp="t", run_id="second"), str(path))
+
+        assert read_journal("", KEY, str(path)).run_id == "first"
+
+    def test_no_bucket_and_no_path_returns_none(self) -> None:
+        assert read_journal("", KEY, "") is None
+        write_journal("", KEY, RunJournal(timestamp="t", run_id="x"), "")  # must not raise
+
+    def test_a_configured_bucket_still_wins(self, tmp_path) -> None:
+        """One env var flips back to S3 — the local path is not consulted."""
+        path = tmp_path / "journal.json"
+        path.write_text(RunJournal(timestamp="t", run_id="stale-local").model_dump_json())
+
+        mock_s3 = MagicMock()
+        mock_s3.get_object.return_value = {
+            "Body": _s3_body(RunJournal(timestamp="t", run_id="from-s3"))
+        }
+        with patch("boto3.client", return_value=mock_s3):
+            assert read_journal(BUCKET, KEY, str(path)).run_id == "from-s3"
+
+
 class TestBuildJournal:
     def test_basic(self) -> None:
         now = datetime(2026, 3, 9, 14, 0, tzinfo=UTC)  # Monday


### PR DESCRIPTION
## Why

PR #57 moved the run journal to S3. Its deployment step 2 — AWS credentials into the Secret, `AGENT_JOURNAL_S3_BUCKET` into the ConfigMap — was never executed. The bucket itself exists (`s3://missingtable-match-scraper`, from `missingtable-platform-bootstrap#30`), but the cluster never points at it, and the `AGENT_JOURNAL_PATH` key the live ConfigMap still carries has been dead since `journal_path` stopped existing as a setting — `extra: "ignore"` discards it silently.

Both call sites in `cli/main.py` are guarded by `if settings.journal_s3_bucket`, so on the cluster the journal has been neither read nor written since **11 April 2026**. The PVC copy is that stale; the one object in S3 is from a laptop run on 2 May.

The consequence is not cosmetic. `apply_modifiers` receives `journal=None` and returns the plan untouched, which kills both modifier rules:

* `error_retry` — a target that errored last run is never re-scraped. This is the one that matters.
* `all_scored_skip` — off too, costing redundant scraping and nothing else.

## What

* `read_journal` / `write_journal` dispatch on the bucket, exactly as PR #71 did for the release watcher. Bucket set → S3, unchanged. Bucket unset → JSON at `AGENT_JOURNAL_PATH`, default `/data/agent-state/journal.json`, on the PVC the agent CronJob already mounts. One env var switches back.
* Local writes are temp-file-plus-rename: a truncated journal reads as no memory at all, which is the failure this is meant to prevent.
* **Behaviour change:** dry runs no longer write a journal. They did before, and a dry run's entries claim matches it never submitted — enough for `all_scored_skip` to make the next real run skip the target. Flagging it since it is not strictly required by the ticket, but leaving it would have made the local backend's first dry run actively harmful.

No manifest change: the agent CronJob already mounts the PVC at the right path, and the live ConfigMap's `AGENT_JOURNAL_PATH` value matches the new default exactly — so that key becomes live again rather than needing removal.

## Tests

171 pass. New `TestLocalFileJournal` covers round trip, missing file, corrupt file, parent-directory creation, write failure, that a failed write preserves the previous journal, that no-bucket-no-path returns `None` without raising, and that a configured bucket still wins over a populated local path.

## Verify after merge

Trigger the agent CronJob manually and confirm `journal.json` on the PVC has a fresh mtime and a current `run_id`, then check the following run logs `journal.loaded`.

Fixes SB-555

🤖 Generated with [Claude Code](https://claude.com/claude-code)
