### PR TITLE
chore: Reconcile K3s manifests with the live cluster

### DIFF
--- a/k3s/deploy.sh
+++ b/k3s/deploy.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 # Deploy match-scraper-agent stack to K3s.
 #
+# ⚠️  DO NOT RUN THIS AGAINST rancher-desktop — it is production for the
+# scraper pipeline, and this script deploys more than the agent:
+#
+#   * rabbitmq/{pvc,deployment,service}.yaml stands up a SECOND broker. The
+#     Celery workers consume from messaging-rabbitmq (the messaging-platform
+#     Helm release), not from this one.
+#   * qop-rankings/cronjob.yaml is deliberately not deployed — see SB-544.
+#
+# The ConfigMap itself is safe to apply as of SB-558: its RabbitMQ hostname
+# now matches the live broker, and the dead LLM-era keys are gone. Apply
+# individual manifests:
+#
+#   kubectl apply -f k3s/match-scraper-agent/configmap.yaml
+#   kubectl apply -f k3s/match-scraper-agent/cronjob.yaml
+#   kubectl apply -f k3s/release-watch/cronjob.yaml
+#
 # Applies: namespace → RabbitMQ (pvc, deployment, service) →
 #          match-scraper-agent (configmap, secret, cronjob) →
 #          qop-rankings (cronjob) → release-watch (cronjob)
@@ -8,9 +24,9 @@
 # Reads envs/.env.prod for secrets and generates the K8s Secret manifest.
 #
 # Required vars in envs/.env.prod:
-#   AGENT_ANTHROPIC_API_KEY       — API key (or "agent-via-proxy" when using proxy)
 #   AGENT_MISSING_TABLE_API_KEY   — missing-table API key
-#   AGENT_TELEGRAM_BOT_TOKEN     — Telegram bot token for notifications
+#   AGENT_TELEGRAM_BOT_TOKEN      — Telegram bot token for notifications
+#   AGENT_TELEGRAM_CHAT_ID        — Telegram chat to notify
 
 set -euo pipefail
 
@@ -23,8 +39,8 @@ if [[ ! -f "$ENV_FILE" ]]; then
   echo "Error: $ENV_FILE not found"
   echo ""
   echo "Create it with at least:"
-  echo "  AGENT_ANTHROPIC_API_KEY=..."
   echo "  AGENT_MISSING_TABLE_API_KEY=..."
+  echo "  AGENT_TELEGRAM_BOT_TOKEN=..."
   exit 1
 fi
 
@@ -35,8 +51,8 @@ set +a
 
 # --- Validate required vars ---
 missing=()
-[[ -z "${AGENT_ANTHROPIC_API_KEY:-}" ]]     && missing+=("AGENT_ANTHROPIC_API_KEY")
 [[ -z "${AGENT_MISSING_TABLE_API_KEY+x}" ]] && missing+=("AGENT_MISSING_TABLE_API_KEY")
+[[ -z "${AGENT_TELEGRAM_BOT_TOKEN:-}" ]]    && missing+=("AGENT_TELEGRAM_BOT_TOKEN")
 
 if [[ ${#missing[@]} -gt 0 ]]; then
   echo "Error: missing required vars in $ENV_FILE:"
@@ -55,9 +71,9 @@ metadata:
   namespace: match-scraper
 type: Opaque
 stringData:
-  AGENT_ANTHROPIC_API_KEY: "$AGENT_ANTHROPIC_API_KEY"
   AGENT_MISSING_TABLE_API_KEY: "$AGENT_MISSING_TABLE_API_KEY"
   AGENT_TELEGRAM_BOT_TOKEN: "$AGENT_TELEGRAM_BOT_TOKEN"
+  AGENT_TELEGRAM_CHAT_ID: "${AGENT_TELEGRAM_CHAT_ID:-}"
 EOF
 
 echo "Generated $SECRET_FILE"

--- a/k3s/match-scraper-agent/configmap.yaml
+++ b/k3s/match-scraper-agent/configmap.yaml
@@ -4,19 +4,22 @@ metadata:
   name: match-scraper-agent-config
   namespace: match-scraper
 data:
-  AGENT_RABBITMQ_URL: "amqp://admin:admin123@rabbitmq.match-scraper.svc.cluster.local:5672//"
+  # messaging-rabbitmq, not rabbitmq — the broker the Celery workers actually
+  # consume from. Pointing at the wrong host publishes matches into a void,
+  # and this line disagreeing with the cluster is the whole reason deploy.sh
+  # carried a "do not run" warning.
+  AGENT_RABBITMQ_URL: "amqp://admin:admin123@messaging-rabbitmq.match-scraper.svc.cluster.local:5672//"
   AGENT_QUEUE_NAME: "matches.prod"
   AGENT_LEAGUE: "Homegrown"
   AGENT_AGE_GROUP: "U14"
   AGENT_DIVISION: "Northeast"
   AGENT_MISSING_TABLE_API_URL: "https://api.missingtable.com"
   MISSING_TABLE_API_BASE_URL: "https://api.missingtable.com"
-  AGENT_JOURNAL_S3_BUCKET: "missingtable-match-scraper"
-  AGENT_JOURNAL_S3_KEY: "journal/latest.json"
-  # Schedule release watcher — shares the journal bucket. Without remote
-  # state the watcher would re-announce a release on every CronJob run.
-  AGENT_RELEASE_WATCH_S3_KEY: "release-watch/state.json"
+  # Cross-run state (run journal + release watcher) lives on the agent-state
+  # PVC. Both stores fall back to S3 if AGENT_JOURNAL_S3_BUCKET is set, but
+  # the cluster has no AWS credentials, so the file paths are the live ones.
+  AGENT_JOURNAL_PATH: "/data/agent-state/journal.json"
+  AGENT_RELEASE_WATCH_STATE_PATH: "/data/agent-state/release-watch.json"
   AGENT_DRY_RUN: "false"
   AGENT_JSON_LOGS: "true"
   AGENT_AUDIT_SEASON_START: "2026-02-01"
-  AGENT_TELEGRAM_CHAT_ID: "-5109858197"

--- a/k3s/match-scraper-agent/secret.yaml.example
+++ b/k3s/match-scraper-agent/secret.yaml.example
@@ -5,12 +5,15 @@ metadata:
   namespace: match-scraper
 type: Opaque
 stringData:
-  # Dummy value — the iron-claw proxy handles the real Anthropic API key.
-  # This satisfies the Anthropic SDK's requirement for an API key header.
-  AGENT_ANTHROPIC_API_KEY: "agent-via-proxy"
   AGENT_MISSING_TABLE_API_KEY: ""
-  # AWS credentials for S3 journal storage (missingtable-match-scraper bucket)
-  # Get values from: tofu output aws_access_key_id / tofu output -raw aws_secret_access_key
-  # in clouds/aws/global/match-scraper/
-  AWS_ACCESS_KEY_ID: ""
-  AWS_SECRET_ACCESS_KEY: ""
+  # Telegram run reports and release announcements. The chat ID lives here
+  # rather than in the ConfigMap — it identifies a private chat.
+  AGENT_TELEGRAM_BOT_TOKEN: ""
+  AGENT_TELEGRAM_CHAT_ID: ""
+  # No AWS credentials: cross-run state (run journal and release-watch state)
+  # is kept on the agent-state PVC. To switch to S3, set
+  # AGENT_JOURNAL_S3_BUCKET in the ConfigMap and add AWS_ACCESS_KEY_ID /
+  # AWS_SECRET_ACCESS_KEY here.
+  #
+  # No Anthropic key either: PR #42 replaced the PydanticAI agent with a
+  # deterministic rules engine, and nothing in src/ calls an LLM.


### PR DESCRIPTION
## Why

`k3s/match-scraper-agent/configmap.yaml` pointed `AGENT_RABBITMQ_URL` at `rabbitmq.match-scraper`, while the Celery workers consume from `messaging-rabbitmq`. Applying it would have published every match into a void. Of the four divergences behind the standing "never run `deploy.sh`" warning, **this was the only one that could actually break production** — the other three are keys nothing reads.

## What

**The hostname fix**, plus removal of config for things that no longer exist. `AgentSettings` has `extra: "ignore"`, so these were silently discarded — they read like working configuration and were not:

| Removed | Why |
|---|---|
| `AGENT_MODEL_NAME`, `AGENT_PROXY_BASE_URL`, `AGENT_PROXY_ENABLED`, `AGENT_MIN_TOKEN_BUDGET` | dead since PR #42 replaced PydanticAI with the rules engine — no LLM in `src/` |
| `AGENT_ANTHROPIC_API_KEY` (Secret + `deploy.sh`) | same; an unused credential is worth removing on its own |
| `AGENT_JOURNAL_S3_BUCKET`, `AGENT_JOURNAL_S3_KEY`, `AGENT_RELEASE_WATCH_S3_KEY` | replaced by the PVC paths the cluster actually uses (SB-554, SB-555). Setting the bucket still switches both stores back to S3 |

`AGENT_TELEGRAM_CHAT_ID` moves from the ConfigMap to the Secret, matching the cluster and keeping a private chat ID out of a ConfigMap.

`deploy.sh` keeps a warning, but now states the reasons that are actually true: it stands up a **second** RabbitMQ, and it deploys the QoP CronJob that SB-544 deliberately leaves undeployed. The ConfigMap is now safe to apply on its own, and the header says so.

## Verification

The ConfigMap was applied. `kubectl diff` before it showed a purely additive change — three new keys, no value changes, hostname already matching — and after it reports no difference at all. **Repo and cluster are now identical**, for the first time in this investigation.

Cluster-side removals done alongside (not in this diff): the four dead keys patched out of the live ConfigMap and `AGENT_ANTHROPIC_API_KEY` out of the live Secret, via targeted `--type=json` removals rather than an apply.

Fixes SB-558

🤖 Generated with [Claude Code](https://claude.com/claude-code)
